### PR TITLE
Fix user existence check

### DIFF
--- a/providers/user.rb
+++ b/providers/user.rb
@@ -2,7 +2,7 @@
 # Author:: Derek Groh (<dgroh@arch.tamu.edu>)
 # Cookbook Name:: windows_ad
 # Provider:: user
-# 
+#
 # Copyright 2013, Texas A&M
 #
 # Permission is hereby granted, free of charge, to any person obtaining
@@ -59,7 +59,7 @@ action :modify do
 
     new_resource.options.each do |option, value|
       cmd << " -#{option} #{value}"
-      #  [-upn UPN] [-fn FirstName] [-mi Initial] [-ln LastName] [-display DisplayName] [-empid EmployeeID] [-pwd (Password | *)] [-desc Description] [-office Office] [-tel PhoneNumber] [-email E-mailAddress] [-hometel HomePhoneNumber] [-pager PagerNumber] [-mobile CellPhoneNumber] [-fax FaxNumber] [-iptel IPPhoneNumber] [-webpg WebPage] [-title Title] [-dept Department] [-company Company] [-mgr Manager] [-hmdir HomeDirectory] [-hmdrv DriveLetter:] [-profile ProfilePath] [-loscr ScriptPath] [-mustchpwd {yes | no}] [-canchpwd {yes | no}] [-reversiblepwd {yes | no}] [-pwdneverexpires {yes | no}] [-acctexpires NumberOfDays] [-disabled {yes | no}] [{-s Server | -d Domain}] [-u UserName] [-p {Password | *}][-c] [-q] [{-uc | -uco | -uci}] 
+      #  [-upn UPN] [-fn FirstName] [-mi Initial] [-ln LastName] [-display DisplayName] [-empid EmployeeID] [-pwd (Password | *)] [-desc Description] [-office Office] [-tel PhoneNumber] [-email E-mailAddress] [-hometel HomePhoneNumber] [-pager PagerNumber] [-mobile CellPhoneNumber] [-fax FaxNumber] [-iptel IPPhoneNumber] [-webpg WebPage] [-title Title] [-dept Department] [-company Company] [-mgr Manager] [-hmdir HomeDirectory] [-hmdrv DriveLetter:] [-profile ProfilePath] [-loscr ScriptPath] [-mustchpwd {yes | no}] [-canchpwd {yes | no}] [-reversiblepwd {yes | no}] [-pwdneverexpires {yes | no}] [-acctexpires NumberOfDays] [-disabled {yes | no}] [{-s Server | -d Domain}] [-u UserName] [-p {Password | *}][-c] [-q] [{-uc | -uco | -uci}]
     end
 
     execute "Modify_#{new_resource.name}" do
@@ -139,8 +139,8 @@ def exists?
     user = Mixlib::ShellOut.new("dsquery user -name \"#{reverse_name}\"").run_command
     contact.stdout.include? "DC" or user.stdout.include? "DC"
   else
-    contact = Mixlib::ShellOut.new("dsquery contact -name #{new_resource.name}").run_command
-    user = Mixlib::ShellOut.new("dsquery user -name #{new_resource.name}").run_command
+    contact = Mixlib::ShellOut.new("dsquery contact -name \"#{new_resource.name}\"").run_command
+    user = Mixlib::ShellOut.new("dsquery user -name \"#{new_resource.name}\"").run_command
     contact.stdout.include? "DC" or user.stdout.include? "DC"
   end
 end


### PR DESCRIPTION
Resource `windows_ad_user` fails with `ArgumentError: invalid Unicode escape` when trying to create already existing user.