### PR TITLE
Group member provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,32 @@ Resource/Provider
              "pwd" => "Passw0rd"
            })
     end
+
+`group_member`
+-------
+
+### Actions
+- :add: Adds a user to a group.
+- :remove: Removes a user from a group.
+
+### Attribute Parameters
+
+- user_name: user name attribute. Name of the user object.
+- group_name: group name attribute. Name of the group object.
+- domain_name: FQDN.
+- user_ou: Organization Unit path where user object is located.
+- group_ou: Organization Unit path where group object is located.
+
+### Examples
+
+    # Add user "Joe Smith" in the Users OU to group "Admins" in OU "AD/Groups"
+    windows_ad_group_member 'Joe Smith' do
+      action :create
+      group_name  'Admins'
+      domain_name 'contoso.com'
+      user_ou 'users'
+      grou_ou 'AD/Groups'
+    end
     
 
 Contributing

--- a/providers/contact.rb
+++ b/providers/contact.rb
@@ -117,9 +117,9 @@ action :delete do
 end
 
 def dn
-  dn = "cn=#{new_resource.name},"
+  dn = "CN=#{new_resource.name},"
   dn << new_resource.ou.split("/").reverse.map { |k| "OU=#{k}" }.join(",") << ","
-  dn << new_resource.domain_name.split(".").map! { |k| "dc=#{k}" }.join(",")
+  dn << new_resource.domain_name.split(".").map! { |k| "DC=#{k}" }.join(",")
 end
 
 def exists?

--- a/providers/group_member.rb
+++ b/providers/group_member.rb
@@ -1,0 +1,88 @@
+#
+# Author:: Miguel Ferreira (<miguelferreira@me.com>)
+# Cookbook Name:: windows_ad
+# Provider:: group_member
+# 
+# Copyright 2015, Schuberg Philis B.V.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+require 'mixlib/shellout'
+
+action :add do
+  group_dn = dn(new_resource.group_name, new_resource.group_ou, new_resource.domain_name)
+  user_dn  = dn(new_resource.user_name,  new_resource.user_ou,  new_resource.domain_name)
+
+  if is_member_of?(user_dn, group_dn)
+    Chef::Log.debug("The user is already member of the group")
+    new_resource.updated_by_last_action(false)
+  else
+    execute "Add_user_#{new_resource.user_name}_to_group_#{new_resource.group_name}" do
+      command dsmod_group_cmd(group_dn, user_dn, '-addmbr')
+    end
+
+    new_resource.updated_by_last_action(true)
+  end
+end
+
+action :remove do
+  group_dn = dn(new_resource.group_name, new_resource.group_ou, new_resource.domain_name)
+  user_dn  = dn(new_resource.user_name,  new_resource.user_ou,  new_resource.domain_name)
+
+  if is_member_of?(user_dn, group_dn)
+    execute "Remove_user_#{new_resource.user_name}_from_group_#{new_resource.group_name}" do
+      command dsmod_group_cmd(group_dn, user_dn, '-rmmbr')
+    end
+
+    new_resource.updated_by_last_action(true)
+  else
+    Chef::Log.error("User is not a member of the group")
+    new_resource.updated_by_last_action(false)
+  end
+end
+
+def dsmod_group_cmd(group_dn, user_dn, option)
+  cmd = "dsmod"
+  cmd << " group "
+  cmd << "\""
+  cmd << group_dn
+  cmd << "\""
+  cmd << " #{option} "
+  cmd << "\""
+  cmd << user_dn
+  cmd << "\""
+end
+
+def dn(name, ou, domain)
+  dn = "CN=#{name},"
+  if /(U|u)sers/.match(ou)
+    dn << "CN=#{ou},"
+  else
+    dn << ou.split("/").reverse.map! { |k| "OU=#{k}" }.join(",")
+    dn << ","
+  end
+  dn << domain.split(".").map! { |k| "DC=#{k}" }.join(",")
+end
+
+def is_member_of?(user_dn, group_dn)
+  check = Mixlib::ShellOut.new("dsget group  \"#{group_dn}\"  -members").run_command
+  check.stdout.include?(user_dn)
+end

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -119,17 +119,17 @@ end
 def dn
   if new_resource.reverse == "true"
     name = new_resource.name.split(" ").reverse.map! { |k| k }.join("\\, ")
-    dn = "cn=#{name},"
+    dn = "CN=#{name},"
   else
-    dn = "cn=#{new_resource.name},"
+    dn = "CN=#{new_resource.name},"
   end
   if /(U|u)sers/.match(new_resource.ou)
-    dn << "cn=#{new_resource.ou},"
+    dn << "CN=#{new_resource.ou},"
   else
-    dn << new_resource.ou.split("/").reverse.map! { |k| "ou=#{k}" }.join(",")
+    dn << new_resource.ou.split("/").reverse.map! { |k| "OU=#{k}" }.join(",")
     dn << ","
   end
-  dn << new_resource.domain_name.split(".").map! { |k| "dc=#{k}" }.join(",")
+  dn << new_resource.domain_name.split(".").map! { |k| "DC=#{k}" }.join(",")
 end
 
 def exists?

--- a/resources/group_member.rb
+++ b/resources/group_member.rb
@@ -1,0 +1,35 @@
+#
+# Author:: Miguel Ferreira (<miguelferreira@me.com>)
+# Cookbook Name:: windows_ad
+# Provider:: group_member
+# 
+# Copyright 2015, Schuberg Philis B.V.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+actions :add, :remove
+default_action :add
+
+attribute :user_name, :kind_of => String, :name_attribute => true
+attribute :group_name, :kind_of => String, :required => true
+attribute :domain_name, :kind_of => String
+attribute :user_ou, :kind_of => String
+attribute :group_ou, :kind_of => String


### PR DESCRIPTION
Hi,

I've been using out this cookbook and it works just great. I did miss a feature to add users to a group in a simpler way, hence this pull request.

It would already be possible to add/remove a user to/from a group with the current group provider.
However, using the parameters available to `dsmod group`, one would have to specify the distinguished name of the user in full.
This would mean that to specify the creation of a user, one would set a user name a domain name and a organisational unit in the form of "ou1/ou2/ou3". But then to make the user a member of a group one would have to specify the distinguished name of the user in the form of "CN=username,OU=ou3,OU=ou2,OU=ou1,DC=domain".
The provider group_member attempts to improve on this, by introducing logic that computes the distinguished name of the user and the group based on attributes similar to the ones used in the group and user providers.

The provider has been tested using vagrant, but I did not include the testing files because I saw that `Vagrantfile` was listed in `.gitignore`. I will be more than happy to include the test config I have if that would be desired.