### PR TITLE
Refactor command options to separate method

### DIFF
--- a/providers/computer.rb
+++ b/providers/computer.rb
@@ -36,16 +36,13 @@ action :create do
     cmd << " computer "
     cmd << dn
 
-    new_resource.options.each do |option, value|
-     cmd << " -#{option} #{value}"
-     # [-samid SAMName] [-desc Description] [-locLocation] [-memberof GroupDN ...] [{-s Server | -d Domain}] [-uUserName] [-p {Password | *}] [-q] [{-uc | -uco | -uci}]
+    cmd << cmd_options(new_resource.options)
+
+    execute "Create_#{new_resource.name}" do
+      command cmd
     end
 
-  execute "Create_#{new_resource.name}" do
-    command cmd
-  end
-
-  new_resource.updated_by_last_action(true)
+    new_resource.updated_by_last_action(true)
   end
 end
 
@@ -55,10 +52,7 @@ action :modify do
     cmd << " computer "
     cmd << dn
 
-    new_resource.options.each do |option, value|
-      cmd << " -#{option} #{value}"
-      # [-desc Description] [-loc Location] [-disabled {yes | no}] [-reset] [{-s Server | -d Domain}] [-u UserName] [-p {Password | *}] [-c] [-q] [{-uc | -uco | -uci}] 
-    end
+    cmd << cmd_options(new_resource.options)
 
     execute "Modify_#{new_resource.name}" do
       command cmd
@@ -76,10 +70,7 @@ action :move do
     cmd = "dsmove "
     cmd << dn
 
-    new_resource.options.each do |option, value|
-      cmd << " -#{option} #{value}"
-      # [-newname NewName] [-newparent ParentDN] [{-s Server | -d Domain}] [-u UserName] [-p  {Password | *}] [-q] [{-uc | -uco | -uci}]
-    end 
+    cmd << cmd_options(new_resource.options) 
 
     execute "Move_#{new_resource.name}" do
       command cmd
@@ -98,10 +89,7 @@ action :delete do
     cmd << dn
     cmd << " -noprompt"
 
-    new_resource.options.each do |option, value|
-      cmd << " -#{option} #{value}"
-      # [-subtree [-exclude]] [-noprompt] [{-s Server | -d Domain}] [-u UserName] [-p {Password | *}][-c][-q][{-uc | -uco | -uci}]
-    end 
+    cmd << cmd_options(new_resource.options) 
 
     execute "Delete_#{new_resource.name}" do
       command cmd
@@ -112,6 +100,15 @@ action :delete do
     Chef::Log.debug("The object has already been removed")
     new_resource.updated_by_last_action(false)  
   end
+end
+
+def cmd_options(options)
+  cmd = ''
+  options.each do |option, value|
+    cmd << " -#{option} \"#{value}\""
+    # [-subtree [-exclude]] [-noprompt] [{-s Server | -d Domain}] [-u UserName] [-p {Password | *}][-c][-q][{-uc | -uco | -uci}]
+  end
+  cmd
 end
 
 def dn

--- a/providers/contact.rb
+++ b/providers/contact.rb
@@ -38,16 +38,13 @@ action :create do
     cmd << dn
     cmd << "\""
 
-    new_resource.options.each do |option, value|
-      cmd << " -#{option} #{value}"
-      # [-fn FirstName] [-mi Initial] [-ln LastName] [-display DisplayName] [-desc Description] [-office Office] [-tel PhoneNumber] [-email Email] [-hometel HomePhoneNumber] [-pager PagerNumber] [-mobile CellPhoneNumber] [-fax FaxNumber] [-iptel IPPhoneNumber] [-title Title] [-dept Department] [-company Company] [{-s Server | -d Domain}] [-u UserName] [-p {Password | *}] [-q] [{-uc | -uco | -uci}]
+    cmd << cmd_options(new_resource.options)
+
+    execute "Create_#{new_resource.name}" do
+      command cmd
     end
 
-  execute "Create_#{new_resource.name}" do
-    command cmd
-  end
-
-  new_resource.updated_by_last_action(true)
+    new_resource.updated_by_last_action(true)
   end
 end
 
@@ -57,10 +54,7 @@ action :modify do
     cmd << " contact "
     cmd << dn
 
-    new_resource.options.each do |option, value|
-      cmd << " -#{option} #{value}"
-      #  [-fn FirstName] [-mi Initial] [-ln LastName] [-display DisplayName] [-desc Description] [-office Office] [-tel PhoneNumber] [-email Email] [-hometel HomePhoneNumber] [-pager PagerNumber] [-mobile CellPhoneNumber] [-fax FaxNumber] [-iptel IPPhoneNumber] [-title Title] [-dept Department] [-company Company] [{-s Server | -d Domain}] [-u UserName][-p {Password | *}] [-c] [-q] [{-uc | -uco | -uci}] 
-    end
+    cmd << cmd_options(new_resource.options)
 
     execute "Modify_#{new_resource.name}" do
       command cmd
@@ -78,10 +72,7 @@ action :move do
     cmd = "dsmove "
     cmd << dn
 
-    new_resource.options.each do |option, value|
-      cmd << " -#{option} #{value}"
-      # [-newname NewName] [-newparent ParentDN] [{-s Server | -d Domain}] [-u UserName] [-p  {Password | *}] [-q] [{-uc | -uco | -uci}]
-    end
+    cmd << cmd_options(new_resource.options)
 
     execute "Move_#{new_resource.name}" do
       command cmd
@@ -100,10 +91,7 @@ action :delete do
     cmd << dn
     cmd << " -noprompt"
 
-    new_resource.options.each do |option, value|
-      cmd << " -#{option} #{value}"
-      # [-subtree [-exclude]] [-noprompt] [{-s Server | -d Domain}] [-u UserName] [-p {Password | *}][-c][-q][{-uc | -uco | -uci}]
-    end
+    cmd << cmd_options(new_resource.options)
 
     execute "Delete_#{new_resource.name}" do
       command cmd
@@ -114,6 +102,15 @@ action :delete do
     Chef::Log.debug("The object has already been removed")
     new_resource.updated_by_last_action(false)
   end
+end
+
+def cmd_options(options)
+  cmd = ''
+  options.each do |option, value|
+    cmd << " -#{option} \"#{value}\""
+    # [-subtree [-exclude]] [-noprompt] [{-s Server | -d Domain}] [-u UserName] [-p {Password | *}][-c][-q][{-uc | -uco | -uci}]
+  end
+  cmd
 end
 
 def dn

--- a/providers/group.rb
+++ b/providers/group.rb
@@ -38,16 +38,13 @@ action :create do
     cmd << dn
     cmd << "\""
 
-    new_resource.options.each do |option, value|
-     cmd << " -#{option} #{value}"
-     # [-secgrp {yes | no}] [-scope {l | g | u}] [-samid SAMName] [-desc Description] [-memberof Group ...] [-members Member ...] [{-s Server | -d Domain}] [-u UserName] [-p {Password | *}] [-q] [{-uc | -uco | -uci}]
+    cmd << cmd_options(new_resource.options)
+
+    execute "Create_#{new_resource.name}" do
+      command cmd
     end
 
-  execute "Create_#{new_resource.name}" do
-    command cmd
-  end
-
-  new_resource.updated_by_last_action(true)
+    new_resource.updated_by_last_action(true)
   end
 end
 
@@ -57,10 +54,7 @@ action :modify do
     cmd << " group "
     cmd << dn
 
-    new_resource.options.each do |option, value|
-      cmd << " -#{option} #{value}"
-      # [-samid SAMName] [-desc Description] [-secgrp {yes | no}] [-scope {l | g | u}] [{-addmbr | -rmmbr | -chmbr} MemberDN ...] [{-s Server | -d Domain}] [-u UserName] [-p {Password | *}] [-c] [-q] [{-uc | -uco | -uci}] 
-    end 
+    cmd << cmd_options(new_resource.options) 
 
     execute "Modify_#{new_resource.name}" do
       command cmd
@@ -78,10 +72,7 @@ action :move do
     cmd = "dsmove "
     cmd << dn
 
-    new_resource.options.each do |option, value|
-      cmd << " -#{option} #{value}"
-      # [-newname NewName] [-newparent ParentDN] [{-s Server | -d Domain}] [-u UserName] [-p  {Password | *}] [-q] [{-uc | -uco | -uci}]
-    end
+    cmd << cmd_options(new_resource.options)
 
     execute "Move_#{new_resource.name}" do
       command cmd
@@ -100,10 +91,7 @@ action :delete do
     cmd << dn
     cmd << " -noprompt"
 
-    new_resource.options.each do |option, value|
-      cmd << " -#{option} #{value}"
-      # [-subtree [-exclude]] [-noprompt] [{-s Server | -d Domain}] [-u UserName] [-p {Password | *}][-c][-q][{-uc | -uco | -uci}]
-    end
+    cmd << cmd_options(new_resource.options)
 
     execute "Delete_#{new_resource.name}" do
       command cmd
@@ -114,6 +102,15 @@ action :delete do
     Chef::Log.debug("The object has already been removed")
     new_resource.updated_by_last_action(false)  
   end
+end
+
+def cmd_options(options)
+  cmd = ''
+  options.each do |option, value|
+    cmd << " -#{option} \"#{value}\""
+    # [-subtree [-exclude]] [-noprompt] [{-s Server | -d Domain}] [-u UserName] [-p {Password | *}][-c][-q][{-uc | -uco | -uci}]
+  end
+  cmd
 end
 
 def dn

--- a/providers/ou.rb
+++ b/providers/ou.rb
@@ -40,16 +40,13 @@ action :create do
       cmd << dn
       cmd << "\""
 
-      new_resource.options.each do |option, value|
-      cmd << " -#{option} #{value}"
-      # [-desc Description] [{-s Server | -d Domain}][-u UserName] [-p {Password | *}] [-q] [{-uc | -uco | -uci}]
-      end
+      cmd << cmd_options(new_resource.options)
 
       execute "Create_#{new_resource.name}" do
         command cmd
       end
 
-    new_resource.updated_by_last_action(true)
+      new_resource.updated_by_last_action(true)
     end
   else
     Chef::Log.error("The parent OU does not exist")
@@ -63,10 +60,7 @@ action :modify do
     cmd << " ou "
     cmd << dn
 
-    new_resource.options.each do |option, value|
-      cmd << " -#{option} #{value}"
-      # [-desc Description] [{-s Server | -d Domain}] [-u UserName] [-p {Password | *}][-c] [-q] [{-uc | -uco | -uci}]
-    end
+    cmd << cmd_options(new_resource.options)
 
     execute "Modify_#{new_resource.name}" do
       command cmd
@@ -84,10 +78,7 @@ action :move do
     cmd = "dsmove "
     cmd << dn
 
-    new_resource.options.each do |option, value|
-      cmd << " -#{option} #{value}"
-      # [-newname NewName] [-newparent ParentDN] [{-s Server | -d Domain}] [-u UserName] [-p  {Password | *}] [-q] [{-uc | -uco | -uci}]
-    end
+    cmd << cmd_options(new_resource.options)
 
     execute "Move_#{new_resource.name}" do
       command cmd
@@ -106,10 +97,7 @@ action :delete do
     cmd << dn
     cmd << " -noprompt"
 
-    new_resource.options.each do |option, value|
-      cmd << " -#{option} #{value}"
-      # [-subtree [-exclude]] [-noprompt] [{-s Server | -d Domain}] [-u UserName] [-p {Password | *}][-c][-q][{-uc | -uco | -uci}]
-    end
+    cmd << cmd_options(new_resource.options)
 
     execute "Delete_#{new_resource.name}" do
       command cmd
@@ -120,6 +108,15 @@ action :delete do
     Chef::Log.debug("The object has already been removed")
     new_resource.updated_by_last_action(false)
   end
+end
+
+def cmd_options(options)
+  cmd = ''
+  options.each do |option, value|
+    cmd << " -#{option} \"#{value}\""
+    # [-subtree [-exclude]] [-noprompt] [{-s Server | -d Domain}] [-u UserName] [-p {Password | *}][-c][-q][{-uc | -uco | -uci}]
+  end
+  cmd
 end
 
 def dn

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -38,10 +38,7 @@ action :create do
     cmd << dn
     cmd << "\""
 
-    new_resource.options.each do |option, value|
-     cmd << " -#{option} \"#{value}\""
-     #  [-samid SAMName] [-upn UPN] [-fn FirstName] [-mi Initial] [-ln LastName] [-display DisplayName] [-empid EmployeeID] [-pwd {Password | *}] [-desc Description] [-memberof Group ...] [-office Office] [-tel PhoneNumber] [-email Email] [-hometel HomePhoneNumber] [-pager PagerNumber] [-mobile CellPhoneNumber] [-fax FaxNumber] [-iptel IPPhoneNumber] [-webpg WebPage] [-title Title] [-dept Department] [-company Company] [-mgr Manager] [-hmdir HomeDirectory] [-hmdrv DriveLetter:][-profile ProfilePath] [-loscr ScriptPath] [-mustchpwd {yes | no}] [-canchpwd {yes | no}] [-reversiblepwd {yes | no}] [-pwdneverexpires {yes | no}] [-acctexpires NumberOfDays] [-disabled {yes | no}] [{-s Server | -d Domain}] [-u UserName] [-p {Password | *}] [-q] [{-uc | -uco | -uci}]
-    end
+    cmd << cmd_options(new_resource.options)
 
   execute "Create_#{new_resource.name}" do
     command cmd
@@ -57,10 +54,7 @@ action :modify do
     cmd << " user "
     cmd << dn
 
-    new_resource.options.each do |option, value|
-      cmd << " -#{option} #{value}"
-      #  [-upn UPN] [-fn FirstName] [-mi Initial] [-ln LastName] [-display DisplayName] [-empid EmployeeID] [-pwd (Password | *)] [-desc Description] [-office Office] [-tel PhoneNumber] [-email E-mailAddress] [-hometel HomePhoneNumber] [-pager PagerNumber] [-mobile CellPhoneNumber] [-fax FaxNumber] [-iptel IPPhoneNumber] [-webpg WebPage] [-title Title] [-dept Department] [-company Company] [-mgr Manager] [-hmdir HomeDirectory] [-hmdrv DriveLetter:] [-profile ProfilePath] [-loscr ScriptPath] [-mustchpwd {yes | no}] [-canchpwd {yes | no}] [-reversiblepwd {yes | no}] [-pwdneverexpires {yes | no}] [-acctexpires NumberOfDays] [-disabled {yes | no}] [{-s Server | -d Domain}] [-u UserName] [-p {Password | *}][-c] [-q] [{-uc | -uco | -uci}]
-    end
+    cmd << cmd_options(new_resource.options)
 
     execute "Modify_#{new_resource.name}" do
       command cmd
@@ -78,10 +72,7 @@ action :move do
     cmd = "dsmove "
     cmd << dn
 
-    new_resource.options.each do |option, value|
-      cmd << " -#{option} #{value}"
-      # [-newname NewName] [-newparent ParentDN] [{-s Server | -d Domain}] [-u UserName] [-p  {Password | *}] [-q] [{-uc | -uco | -uci}]
-    end
+    cmd << cmd_options(new_resource.options)
 
     execute "Move_#{new_resource.name}" do
       command cmd
@@ -100,10 +91,7 @@ action :delete do
     cmd << dn
     cmd << " -noprompt"
 
-    new_resource.options.each do |option, value|
-      cmd << " -#{option} #{value}"
-      # [-subtree [-exclude]] [-noprompt] [{-s Server | -d Domain}] [-u UserName] [-p {Password | *}][-c][-q][{-uc | -uco | -uci}]
-    end
+    cmd << cmd_options(new_resource.options)
 
     execute "Create_#{new_resource.name}" do
       command cmd
@@ -114,6 +102,15 @@ action :delete do
     Chef::Log.debug("The object has already been removed")
     new_resource.updated_by_last_action(false)
   end
+end
+
+def cmd_options(options)
+  cmd = ''
+  options.each do |option, value|
+    cmd << " -#{option} \"#{value}\""
+    # [-subtree [-exclude]] [-noprompt] [{-s Server | -d Domain}] [-u UserName] [-p {Password | *}][-c][-q][{-uc | -uco | -uci}]
+  end
+  cmd
 end
 
 def dn


### PR DESCRIPTION
This PR refactors the construction of the string with command line options to a separate method.
It reduces code duplication and addresses the issue reported in https://github.com/TAMUArch/cookbook.windows_ad/issues/28