### PR TITLE
Enable adding groups to CN=Users

### DIFF
--- a/providers/group.rb
+++ b/providers/group.rb
@@ -116,10 +116,15 @@ action :delete do
   end
 end
 
-def dn
-  dn = "CN=#{new_resource.name},"
-  dn << new_resource.ou.split("/").reverse.map { |k| "OU=#{k}" }.join(",") << ","
-  dn << new_resource.domain_name.split(".").map! { |k| "DC=#{k}" }.join(",")
+def dn(name, ou, domain)
+  dn = "CN=#{name},"
+  if /(U|u)sers/.match(ou)
+    dn << "CN=#{ou},"
+  else
+    dn << ou.split("/").reverse.map! { |k| "OU=#{k}" }.join(",")
+    dn << ","
+  end
+  dn << domain.split(".").map! { |k| "DC=#{k}" }.join(",")
 end
 
 def exists?


### PR DESCRIPTION
This pull request adds logic to the construction of the group distinguished name in order to enable creating groups in CN=Users. This logic is almost the same as it is used in the user provider.

The change in this PR addresses issue https://github.com/TAMUArch/cookbook.windows_ad/issues/30