### PR TITLE
Allow OU to include the word users

### DIFF
--- a/providers/group.rb
+++ b/providers/group.rb
@@ -115,7 +115,7 @@ end
 
 def dn
   dn = "CN=#{new_resource.name},"
-  if /(U|u)sers/.match(new_resource.ou)
+  if new_resource.ou.downcase == 'users'
     dn << "CN=#{new_resource.ou},"
   else
     dn << new_resource.ou.split("/").reverse.map! { |k| "OU=#{k}" }.join(",")

--- a/providers/group_member.rb
+++ b/providers/group_member.rb
@@ -73,7 +73,7 @@ end
 
 def dn(name, ou, domain)
   dn = "CN=#{name},"
-  if /(U|u)sers/.match(ou)
+  if ou.downcase == 'users'
     dn << "CN=#{ou},"
   else
     dn << ou.split("/").reverse.map! { |k| "OU=#{k}" }.join(",")

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -120,7 +120,7 @@ def dn
   else
     dn = "CN=#{new_resource.name},"
   end
-  if /(U|u)sers/.match(new_resource.ou)
+  if new_resource.ou.downcase == 'users'
     dn << "CN=#{new_resource.ou},"
   else
     dn << new_resource.ou.split("/").reverse.map! { |k| "OU=#{k}" }.join(",")


### PR DESCRIPTION
This PR addresses issue https://github.com/TAMUArch/cookbook.windows_ad/issues/33

It enables the creation of users, groups and group memberships in OUs that contain the word 'users'