### PR TITLE
Specify domain account in resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ Resource/Provider
 - domain_name: FQDN
 - ou: Organization Unit path where object is to be located.
 - options: ability to pass additional options http://technet.microsoft.com/en-us/library/cc754539.aspx
+- cmd_user: user under which the interaction with AD should happen
+- cmd_pass: password for user specified in cmd_user (only needed if user requires password)
+- cmd_domain: domain of the user specified in cmd_user (only needed if user is a domain account)
 
 
 ### Examples
@@ -146,6 +149,16 @@ Resource/Provider
       options ({ "desc" => "computer" })
     end
 
+    # Create computer "workstation1" in the Computers OU using domain admin account
+    windows_ad_computer "workstation1" do
+      action :create
+      domain_name "contoso.com"
+      ou "computers"
+      cmd_user "Administrator"
+      cmd_pass "password"
+      cmd_domain "contoso.com"
+    end
+
 `contact`
 ---------
 
@@ -161,6 +174,9 @@ Resource/Provider
 - domain_name: FQDN
 - ou: Organization Unit path where object is to be located.
 - options: ability to pass additional options http://technet.microsoft.com/en-us/library/cc771883.aspx
+- cmd_user: user under which the interaction with AD should happen
+- cmd_pass: password for user specified in cmd_user (only needed if user requires password)
+- cmd_domain: domain of the user specified in cmd_user (only needed if user is a domain account)
 
 
 ### Examples
@@ -173,6 +189,20 @@ Resource/Provider
       options ({ "fn" => "Bob", 
                  "ln" => "Smith"
                })
+    end
+
+    # Create contact "Bob Smith" in the Users OU with firstname "Bob" and lastname "Smith"
+    # using domain admin account
+    windows_ad_contact "Bob Smith" do
+      action :create
+      domain_name "contoso.com"
+      ou "users"
+      options ({ "fn" => "Bob", 
+                 "ln" => "Smith"
+               })
+      cmd_user "Administrator"
+      cmd_pass "password"
+      cmd_domain "contoso.com"
     end
     
 `group`
@@ -190,6 +220,9 @@ Resource/Provider
 - domain_name: FQDN
 - ou: Organization Unit path where object is to be located.
 - options: ability to pass additional options http://technet.microsoft.com/en-us/library/cc754037.aspx
+- cmd_user: user under which the interaction with AD should happen
+- cmd_pass: password for user specified in cmd_user (only needed if user requires password)
+- cmd_domain: domain of the user specified in cmd_user (only needed if user is a domain account)
 
 
 ### Examples
@@ -209,6 +242,16 @@ Resource/Provider
       options ({ "desc" => "Information Technology Security Group"
                })
     end
+
+    # Create group "IT" in the Users OU using domain admin account
+    windows_ad_group "IT" do
+      action :create
+      domain_name "contoso.com"
+      ou "users"
+      cmd_user "Administrator"
+      cmd_pass "password"
+      cmd_domain "contoso.com"
+    end
     
 `ou`
 ----
@@ -225,6 +268,9 @@ Resource/Provider
 - domain_name: FQDN
 - ou: Organization Unit path where object is to be located.
 - options: ability to pass additional options http://technet.microsoft.com/en-us/library/cc770883.aspx
+- cmd_user: user under which the interaction with AD should happen
+- cmd_pass: password for user specified in cmd_user (only needed if user requires password)
+- cmd_domain: domain of the user specified in cmd_user (only needed if user is a domain account)
 
 
 ### Examples
@@ -240,6 +286,15 @@ Resource/Provider
       action :create
       domain_name "contoso.com"
       ou "Departments"
+    end
+
+    # Create Organizational Unit "Departments" in the root using domain admin account
+    windows_ad_ou "Departments" do
+      action :create
+      domain_name "contoso.com"
+      cmd_user "Administrator"
+      cmd_pass "password"
+      cmd_domain "contoso.com"
     end
     
 `users`
@@ -258,6 +313,9 @@ Resource/Provider
 - ou: Organization Unit path where object is located.
 - options: ability to pass additional options http://technet.microsoft.com/en-us/library/cc731279.aspx
 - reverse: allows the reversing of "First Name Last Name" to "Last Name, First Name"
+- cmd_user: user under which the interaction with AD should happen
+- cmd_pass: password for user specified in cmd_user (only needed if user requires password)
+- cmd_domain: domain of the user specified in cmd_user (only needed if user is a domain account)
 
 ### Examples
 
@@ -276,6 +334,24 @@ Resource/Provider
            })
     end
 
+    # Create user "Joe Smith" in the Users OU using domain admin account
+    windows_ad_user "Joe Smith" do
+      action :create
+      domain_name "contoso.com"
+      ou "users"
+      options ({ "samid" => "JSmith",
+             "upn" => "JSmith@contoso.com",
+             "fn" => "Joe",
+             "ln" => "Smith",
+             "display" => "Smith, Joe",
+             "disabled" => "no",
+             "pwd" => "Passw0rd"
+           })
+      cmd_user "Administrator"
+      cmd_pass "password"
+      cmd_domain "contoso.com"
+    end
+
 `group_member`
 -------
 
@@ -290,6 +366,9 @@ Resource/Provider
 - domain_name: FQDN.
 - user_ou: Organization Unit path where user object is located.
 - group_ou: Organization Unit path where group object is located.
+- cmd_user: user under which the interaction with AD should happen
+- cmd_pass: password for user specified in cmd_user (only needed if user requires password)
+- cmd_domain: domain of the user specified in cmd_user (only needed if user is a domain account)
 
 ### Examples
 
@@ -300,6 +379,18 @@ Resource/Provider
       domain_name 'contoso.com'
       user_ou 'users'
       grou_ou 'AD/Groups'
+    end
+
+    # Add user "Joe Smith" in the Users OU to group "Admins" in OU "AD/Groups" using domain admin account
+    windows_ad_group_member 'Joe Smith' do
+      action :add
+      group_name  'Admins'
+      domain_name 'contoso.com'
+      user_ou 'users'
+      group_ou 'AD/Groups'
+      cmd_user "Administrator"
+      cmd_pass "password"
+      cmd_domain "contoso.com"
     end
     
 

--- a/libraries/cmd_helper.rb
+++ b/libraries/cmd_helper.rb
@@ -8,4 +8,15 @@ class CmdHelper
     cmd
   end
 
+  def self.dn(name, ou, domain)
+    dn = "CN=#{name},"
+    unless ou.nil?
+      if ou.downcase == 'users'
+        dn << "CN=#{ou},"
+      else
+        dn << ou.split("/").reverse.map! { |k| "OU=#{k}" }.join(",") << ","
+      end
+    end
+    dn << domain.split(".").map! { |k| "DC=#{k}" }.join(",")
+  end
 end

--- a/libraries/cmd_helper.rb
+++ b/libraries/cmd_helper.rb
@@ -1,3 +1,5 @@
+require 'mixlib/shellout'
+
 class CmdHelper
 
   def self.cmd_options(options)
@@ -18,5 +20,14 @@ class CmdHelper
       end
     end
     dn << domain.split(".").map! { |k| "DC=#{k}" }.join(",")
+  end
+
+  def self.shell_out(cmd, user, pass, domain)
+    shellout = Mixlib::ShellOut.new(cmd, user: user, password: pass, domain: domain)
+    shellout.run_command
+    if shellout.exitstatus != 0
+      raise "Failed to execute command.\nSTDOUT: #{shellout.stdout}\nSTDERR: #{shellout.stderr}"
+    end
+    shellout
   end
 end

--- a/libraries/cmd_helper.rb
+++ b/libraries/cmd_helper.rb
@@ -1,0 +1,11 @@
+class CmdHelper
+
+  def self.cmd_options(options)
+    cmd = ''
+    options.each do |option, value|
+      cmd << " -#{option} \"#{value}\""
+    end
+    cmd
+  end
+
+end

--- a/providers/computer.rb
+++ b/providers/computer.rb
@@ -34,7 +34,7 @@ action :create do
   else
     cmd = "dsadd"
     cmd << " computer "
-    cmd << dn
+    cmd << CmdHelper.dn(new_resource.name, new_resource.ou, new_resource.domain_name)
 
     cmd << CmdHelper.cmd_options(new_resource.options)
 
@@ -50,7 +50,7 @@ action :modify do
   if exists?
     cmd = "dsmod"
     cmd << " computer "
-    cmd << dn
+    cmd << CmdHelper.dn(new_resource.name, new_resource.ou, new_resource.domain_name)
 
     cmd << CmdHelper.cmd_options(new_resource.options)
 
@@ -68,7 +68,7 @@ end
 action :move do
   if exists?
     cmd = "dsmove "
-    cmd << dn
+    cmd << CmdHelper.dn(new_resource.name, new_resource.ou, new_resource.domain_name)
 
     cmd << CmdHelper.cmd_options(new_resource.options) 
 
@@ -86,7 +86,7 @@ end
 action :delete do
   if exists?
     cmd = "dsrm "
-    cmd << dn
+    cmd << CmdHelper.dn(new_resource.name, new_resource.ou, new_resource.domain_name)
     cmd << " -noprompt"
 
     cmd << CmdHelper.cmd_options(new_resource.options) 
@@ -100,12 +100,6 @@ action :delete do
     Chef::Log.debug("The object has already been removed")
     new_resource.updated_by_last_action(false)  
   end
-end
-
-def dn
-  dn = "CN=#{new_resource.name},"
-  dn << new_resource.ou.split("/").reverse.map { |k| "OU=#{k}" }.join(",") << ","
-  dn << new_resource.domain_name.split(".").map! { |k| "DC=#{k}" }.join(",")
 end
 
 def exists?

--- a/providers/computer.rb
+++ b/providers/computer.rb
@@ -36,7 +36,7 @@ action :create do
     cmd << " computer "
     cmd << dn
 
-    cmd << cmd_options(new_resource.options)
+    cmd << CmdHelper.cmd_options(new_resource.options)
 
     execute "Create_#{new_resource.name}" do
       command cmd
@@ -52,7 +52,7 @@ action :modify do
     cmd << " computer "
     cmd << dn
 
-    cmd << cmd_options(new_resource.options)
+    cmd << CmdHelper.cmd_options(new_resource.options)
 
     execute "Modify_#{new_resource.name}" do
       command cmd
@@ -70,7 +70,7 @@ action :move do
     cmd = "dsmove "
     cmd << dn
 
-    cmd << cmd_options(new_resource.options) 
+    cmd << CmdHelper.cmd_options(new_resource.options) 
 
     execute "Move_#{new_resource.name}" do
       command cmd
@@ -89,7 +89,7 @@ action :delete do
     cmd << dn
     cmd << " -noprompt"
 
-    cmd << cmd_options(new_resource.options) 
+    cmd << CmdHelper.cmd_options(new_resource.options) 
 
     execute "Delete_#{new_resource.name}" do
       command cmd
@@ -100,15 +100,6 @@ action :delete do
     Chef::Log.debug("The object has already been removed")
     new_resource.updated_by_last_action(false)  
   end
-end
-
-def cmd_options(options)
-  cmd = ''
-  options.each do |option, value|
-    cmd << " -#{option} \"#{value}\""
-    # [-subtree [-exclude]] [-noprompt] [{-s Server | -d Domain}] [-u UserName] [-p {Password | *}][-c][-q][{-uc | -uco | -uci}]
-  end
-  cmd
 end
 
 def dn

--- a/providers/computer.rb
+++ b/providers/computer.rb
@@ -38,9 +38,8 @@ action :create do
 
     cmd << CmdHelper.cmd_options(new_resource.options)
 
-    execute "Create_#{new_resource.name}" do
-      command cmd
-    end
+    Chef::Log.info(print_msg("create #{new_resource.name}"))
+    CmdHelper.shell_out(cmd, new_resource.cmd_user, new_resource.cmd_pass, new_resource.cmd_domain)
 
     new_resource.updated_by_last_action(true)
   end
@@ -54,9 +53,8 @@ action :modify do
 
     cmd << CmdHelper.cmd_options(new_resource.options)
 
-    execute "Modify_#{new_resource.name}" do
-      command cmd
-    end
+    Chef::Log.info(print_msg("modify #{new_resource.name}"))
+    CmdHelper.shell_out(cmd, new_resource.cmd_user, new_resource.cmd_pass, new_resource.cmd_domain)
 
     new_resource.updated_by_last_action(true)
   else
@@ -72,9 +70,8 @@ action :move do
 
     cmd << CmdHelper.cmd_options(new_resource.options) 
 
-    execute "Move_#{new_resource.name}" do
-      command cmd
-    end
+    Chef::Log.info(print_msg("move #{new_resource.name}"))
+    CmdHelper.shell_out(cmd, new_resource.cmd_user, new_resource.cmd_pass, new_resource.cmd_domain)
 
     new_resource.updated_by_last_action(true)
   else
@@ -91,9 +88,8 @@ action :delete do
 
     cmd << CmdHelper.cmd_options(new_resource.options) 
 
-    execute "Delete_#{new_resource.name}" do
-      command cmd
-    end  
+    Chef::Log.info(print_msg("delete #{new_resource.name}"))
+    CmdHelper.shell_out(cmd, new_resource.cmd_user, new_resource.cmd_pass, new_resource.cmd_domain)
 
     new_resource.updated_by_last_action(true)
   else
@@ -103,6 +99,11 @@ action :delete do
 end
 
 def exists?
-  check = Mixlib::ShellOut.new("dsquery computer -name \"#{new_resource.name}\"").run_command
+  check = CmdHelper.shell_out("dsquery computer -name \"#{new_resource.name}\"",
+                              new_resource.cmd_user, new_resource.cmd_pass, new_resource.cmd_domain)
   check.stdout.include? "DC"
+end
+
+def print_msg(action)
+  "windows_ad_contact[#{action}]"
 end

--- a/providers/contact.rb
+++ b/providers/contact.rb
@@ -40,9 +40,8 @@ action :create do
 
     cmd << CmdHelper.cmd_options(new_resource.options)
 
-    execute "Create_#{new_resource.name}" do
-      command cmd
-    end
+    Chef::Log.info(print_msg("create #{new_resource.name}"))
+    CmdHelper.shell_out(cmd, new_resource.cmd_user, new_resource.cmd_pass, new_resource.cmd_domain)
 
     new_resource.updated_by_last_action(true)
   end
@@ -56,9 +55,8 @@ action :modify do
 
     cmd << CmdHelper.cmd_options(new_resource.options)
 
-    execute "Modify_#{new_resource.name}" do
-      command cmd
-    end
+    Chef::Log.info(print_msg("modify #{new_resource.name}"))
+    CmdHelper.shell_out(cmd, new_resource.cmd_user, new_resource.cmd_pass, new_resource.cmd_domain)
 
     new_resource.updated_by_last_action(true)
   else
@@ -74,9 +72,8 @@ action :move do
 
     cmd << CmdHelper.cmd_options(new_resource.options)
 
-    execute "Move_#{new_resource.name}" do
-      command cmd
-    end
+    Chef::Log.info(print_msg("move #{new_resource.name}"))
+    CmdHelper.shell_out(cmd, new_resource.cmd_user, new_resource.cmd_pass, new_resource.cmd_domain)
 
     new_resource.updated_by_last_action(true)
   else
@@ -93,9 +90,8 @@ action :delete do
 
     cmd << CmdHelper.cmd_options(new_resource.options)
 
-    execute "Delete_#{new_resource.name}" do
-      command cmd
-    end
+    Chef::Log.info(print_msg("delete #{new_resource.name}"))
+    CmdHelper.shell_out(cmd, new_resource.cmd_user, new_resource.cmd_pass, new_resource.cmd_domain)
 
     new_resource.updated_by_last_action(true)
   else
@@ -105,7 +101,13 @@ action :delete do
 end
 
 def exists?
-  contact = Mixlib::ShellOut.new("dsquery contact -name \"#{new_resource.name}\"").run_command
-  user = Mixlib::ShellOut.new("dsquery user -name #{new_resource.name}").run_command
+  contact = CmdHelper.shell_out("dsquery contact -name \"#{new_resource.name}\"",
+                                new_resource.cmd_user, new_resource.cmd_pass, new_resource.cmd_domain)
+  user = CmdHelper.shell_out("dsquery user -name #{new_resource.name}",
+                             new_resource.cmd_user, new_resource.cmd_pass, new_resource.cmd_domain)
   contact.stdout.include? "DC" or user.stdout.include? "DC"
+end
+
+def print_msg(action)
+  "windows_ad_contact[#{action}]"
 end

--- a/providers/contact.rb
+++ b/providers/contact.rb
@@ -38,7 +38,7 @@ action :create do
     cmd << dn
     cmd << "\""
 
-    cmd << cmd_options(new_resource.options)
+    cmd << CmdHelper.cmd_options(new_resource.options)
 
     execute "Create_#{new_resource.name}" do
       command cmd
@@ -54,7 +54,7 @@ action :modify do
     cmd << " contact "
     cmd << dn
 
-    cmd << cmd_options(new_resource.options)
+    cmd << CmdHelper.cmd_options(new_resource.options)
 
     execute "Modify_#{new_resource.name}" do
       command cmd
@@ -72,7 +72,7 @@ action :move do
     cmd = "dsmove "
     cmd << dn
 
-    cmd << cmd_options(new_resource.options)
+    cmd << CmdHelper.cmd_options(new_resource.options)
 
     execute "Move_#{new_resource.name}" do
       command cmd
@@ -91,7 +91,7 @@ action :delete do
     cmd << dn
     cmd << " -noprompt"
 
-    cmd << cmd_options(new_resource.options)
+    cmd << CmdHelper.cmd_options(new_resource.options)
 
     execute "Delete_#{new_resource.name}" do
       command cmd
@@ -102,15 +102,6 @@ action :delete do
     Chef::Log.debug("The object has already been removed")
     new_resource.updated_by_last_action(false)
   end
-end
-
-def cmd_options(options)
-  cmd = ''
-  options.each do |option, value|
-    cmd << " -#{option} \"#{value}\""
-    # [-subtree [-exclude]] [-noprompt] [{-s Server | -d Domain}] [-u UserName] [-p {Password | *}][-c][-q][{-uc | -uco | -uci}]
-  end
-  cmd
 end
 
 def dn

--- a/providers/contact.rb
+++ b/providers/contact.rb
@@ -35,7 +35,7 @@ action :create do
     cmd = "dsadd"
     cmd << " contact "
     cmd << "\""
-    cmd << dn
+    cmd << CmdHelper.dn(new_resource.name, new_resource.ou, new_resource.domain_name)
     cmd << "\""
 
     cmd << CmdHelper.cmd_options(new_resource.options)
@@ -52,7 +52,7 @@ action :modify do
   if exists?
     cmd = "dsmod"
     cmd << " contact "
-    cmd << dn
+    cmd << CmdHelper.dn(new_resource.name, new_resource.ou, new_resource.domain_name)
 
     cmd << CmdHelper.cmd_options(new_resource.options)
 
@@ -70,7 +70,7 @@ end
 action :move do
   if exists?
     cmd = "dsmove "
-    cmd << dn
+    cmd << CmdHelper.dn(new_resource.name, new_resource.ou, new_resource.domain_name)
 
     cmd << CmdHelper.cmd_options(new_resource.options)
 
@@ -88,7 +88,7 @@ end
 action :delete do
   if exists?
     cmd = "dsrm "
-    cmd << dn
+    cmd << CmdHelper.dn(new_resource.name, new_resource.ou, new_resource.domain_name)
     cmd << " -noprompt"
 
     cmd << CmdHelper.cmd_options(new_resource.options)
@@ -102,12 +102,6 @@ action :delete do
     Chef::Log.debug("The object has already been removed")
     new_resource.updated_by_last_action(false)
   end
-end
-
-def dn
-  dn = "CN=#{new_resource.name},"
-  dn << new_resource.ou.split("/").reverse.map { |k| "OU=#{k}" }.join(",") << ","
-  dn << new_resource.domain_name.split(".").map! { |k| "DC=#{k}" }.join(",")
 end
 
 def exists?

--- a/providers/group.rb
+++ b/providers/group.rb
@@ -35,7 +35,7 @@ action :create do
     cmd = "dsadd"
     cmd << " group "
     cmd << "\""
-    cmd << dn
+    cmd << CmdHelper.dn(new_resource.name, new_resource.ou, new_resource.domain_name)
     cmd << "\""
 
     cmd << CmdHelper.cmd_options(new_resource.options)
@@ -52,7 +52,7 @@ action :modify do
   if exists?
     cmd = "dsmod"
     cmd << " group "
-    cmd << dn
+    cmd << CmdHelper.dn(new_resource.name, new_resource.ou, new_resource.domain_name)
 
     cmd << CmdHelper.cmd_options(new_resource.options) 
 
@@ -70,7 +70,7 @@ end
 action :move do
   if exists?
     cmd = "dsmove "
-    cmd << dn
+    cmd << CmdHelper.dn(new_resource.name, new_resource.ou, new_resource.domain_name)
 
     cmd << CmdHelper.cmd_options(new_resource.options)
 
@@ -88,7 +88,7 @@ end
 action :delete do
   if exists?
     cmd = "dsrm "
-    cmd << dn
+    cmd << CmdHelper.dn(new_resource.name, new_resource.ou, new_resource.domain_name)
     cmd << " -noprompt"
 
     cmd << CmdHelper.cmd_options(new_resource.options)
@@ -102,17 +102,6 @@ action :delete do
     Chef::Log.debug("The object has already been removed")
     new_resource.updated_by_last_action(false)  
   end
-end
-
-def dn
-  dn = "CN=#{new_resource.name},"
-  if new_resource.ou.downcase == 'users'
-    dn << "CN=#{new_resource.ou},"
-  else
-    dn << new_resource.ou.split("/").reverse.map! { |k| "OU=#{k}" }.join(",")
-    dn << ","
-  end
-  dn << new_resource.domain_name.split(".").map! { |k| "DC=#{k}" }.join(",")
 end
 
 def exists?

--- a/providers/group.rb
+++ b/providers/group.rb
@@ -40,9 +40,8 @@ action :create do
 
     cmd << CmdHelper.cmd_options(new_resource.options)
 
-    execute "Create_#{new_resource.name}" do
-      command cmd
-    end
+    Chef::Log.info(print_msg("create #{new_resource.name}"))
+    CmdHelper.shell_out(cmd, new_resource.cmd_user, new_resource.cmd_pass, new_resource.cmd_domain)
 
     new_resource.updated_by_last_action(true)
   end
@@ -56,9 +55,8 @@ action :modify do
 
     cmd << CmdHelper.cmd_options(new_resource.options) 
 
-    execute "Modify_#{new_resource.name}" do
-      command cmd
-    end
+    Chef::Log.info(print_msg("modify #{new_resource.name}"))
+    CmdHelper.shell_out(cmd, new_resource.cmd_user, new_resource.cmd_pass, new_resource.cmd_domain)
 
     new_resource.updated_by_last_action(true)
   else
@@ -74,9 +72,8 @@ action :move do
 
     cmd << CmdHelper.cmd_options(new_resource.options)
 
-    execute "Move_#{new_resource.name}" do
-      command cmd
-    end
+    Chef::Log.info(print_msg("move #{new_resource.name}"))
+    CmdHelper.shell_out(cmd, new_resource.cmd_user, new_resource.cmd_pass, new_resource.cmd_domain)
 
     new_resource.updated_by_last_action(true)
   else
@@ -93,9 +90,8 @@ action :delete do
 
     cmd << CmdHelper.cmd_options(new_resource.options)
 
-    execute "Delete_#{new_resource.name}" do
-      command cmd
-    end
+    Chef::Log.info(print_msg("delete #{new_resource.name}"))
+    CmdHelper.shell_out(cmd, new_resource.cmd_user, new_resource.cmd_pass, new_resource.cmd_domain)
 
     new_resource.updated_by_last_action(true)
   else
@@ -107,4 +103,8 @@ end
 def exists?
   check = Mixlib::ShellOut.new("dsquery group -name \"#{new_resource.name}\"").run_command
   check.stdout.include? "DC"
+end
+
+def print_msg(action)
+  "windows_ad_group[#{action}]"
 end

--- a/providers/group.rb
+++ b/providers/group.rb
@@ -38,7 +38,7 @@ action :create do
     cmd << dn
     cmd << "\""
 
-    cmd << cmd_options(new_resource.options)
+    cmd << CmdHelper.cmd_options(new_resource.options)
 
     execute "Create_#{new_resource.name}" do
       command cmd
@@ -54,7 +54,7 @@ action :modify do
     cmd << " group "
     cmd << dn
 
-    cmd << cmd_options(new_resource.options) 
+    cmd << CmdHelper.cmd_options(new_resource.options) 
 
     execute "Modify_#{new_resource.name}" do
       command cmd
@@ -72,7 +72,7 @@ action :move do
     cmd = "dsmove "
     cmd << dn
 
-    cmd << cmd_options(new_resource.options)
+    cmd << CmdHelper.cmd_options(new_resource.options)
 
     execute "Move_#{new_resource.name}" do
       command cmd
@@ -91,7 +91,7 @@ action :delete do
     cmd << dn
     cmd << " -noprompt"
 
-    cmd << cmd_options(new_resource.options)
+    cmd << CmdHelper.cmd_options(new_resource.options)
 
     execute "Delete_#{new_resource.name}" do
       command cmd
@@ -102,15 +102,6 @@ action :delete do
     Chef::Log.debug("The object has already been removed")
     new_resource.updated_by_last_action(false)  
   end
-end
-
-def cmd_options(options)
-  cmd = ''
-  options.each do |option, value|
-    cmd << " -#{option} \"#{value}\""
-    # [-subtree [-exclude]] [-noprompt] [{-s Server | -d Domain}] [-u UserName] [-p {Password | *}][-c][-q][{-uc | -uco | -uci}]
-  end
-  cmd
 end
 
 def dn

--- a/providers/group_member.rb
+++ b/providers/group_member.rb
@@ -28,8 +28,8 @@
 require 'mixlib/shellout'
 
 action :add do
-  group_dn = dn(new_resource.group_name, new_resource.group_ou, new_resource.domain_name)
-  user_dn  = dn(new_resource.user_name,  new_resource.user_ou,  new_resource.domain_name)
+  group_dn = CmdHelper.dn(new_resource.group_name, new_resource.group_ou, new_resource.domain_name)
+  user_dn  = CmdHelper.dn(new_resource.user_name,  new_resource.user_ou,  new_resource.domain_name)
 
   if is_member_of?(user_dn, group_dn)
     Chef::Log.debug("The user is already member of the group")
@@ -44,8 +44,8 @@ action :add do
 end
 
 action :remove do
-  group_dn = dn(new_resource.group_name, new_resource.group_ou, new_resource.domain_name)
-  user_dn  = dn(new_resource.user_name,  new_resource.user_ou,  new_resource.domain_name)
+  group_dn = CmdHelper.dn(new_resource.group_name, new_resource.group_ou, new_resource.domain_name)
+  user_dn  = CmdHelper.dn(new_resource.user_name,  new_resource.user_ou,  new_resource.domain_name)
 
   if is_member_of?(user_dn, group_dn)
     execute "Remove_user_#{new_resource.user_name}_from_group_#{new_resource.group_name}" do
@@ -69,17 +69,6 @@ def dsmod_group_cmd(group_dn, user_dn, option)
   cmd << "\""
   cmd << user_dn
   cmd << "\""
-end
-
-def dn(name, ou, domain)
-  dn = "CN=#{name},"
-  if ou.downcase == 'users'
-    dn << "CN=#{ou},"
-  else
-    dn << ou.split("/").reverse.map! { |k| "OU=#{k}" }.join(",")
-    dn << ","
-  end
-  dn << domain.split(".").map! { |k| "DC=#{k}" }.join(",")
 end
 
 def is_member_of?(user_dn, group_dn)

--- a/providers/group_member.rb
+++ b/providers/group_member.rb
@@ -25,8 +25,6 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 
-require 'mixlib/shellout'
-
 action :add do
   group_dn = CmdHelper.dn(new_resource.group_name, new_resource.group_ou, new_resource.domain_name)
   user_dn  = CmdHelper.dn(new_resource.user_name,  new_resource.user_ou,  new_resource.domain_name)
@@ -35,9 +33,10 @@ action :add do
     Chef::Log.debug("The user is already member of the group")
     new_resource.updated_by_last_action(false)
   else
-    execute "Add_user_#{new_resource.user_name}_to_group_#{new_resource.group_name}" do
-      command dsmod_group_cmd(group_dn, user_dn, '-addmbr')
-    end
+    cmd = dsmod_group_cmd(group_dn, user_dn, '-addmbr')
+
+    Chef::Log.info(print_msg("add #{new_resource.user_name} to #{new_resource.group_name}"))
+    CmdHelper.shell_out(cmd, new_resource.cmd_user, new_resource.cmd_pass, new_resource.cmd_domain)
 
     new_resource.updated_by_last_action(true)
   end
@@ -48,9 +47,10 @@ action :remove do
   user_dn  = CmdHelper.dn(new_resource.user_name,  new_resource.user_ou,  new_resource.domain_name)
 
   if is_member_of?(user_dn, group_dn)
-    execute "Remove_user_#{new_resource.user_name}_from_group_#{new_resource.group_name}" do
-      command dsmod_group_cmd(group_dn, user_dn, '-rmmbr')
-    end
+    cmd = dsmod_group_cmd(group_dn, user_dn, '-rmmbr')
+
+    Chef::Log.info(print_msg("remove #{new_resource.user_name} from #{new_resource.group_name}"))
+    CmdHelper.shell_out(cmd, new_resource.cmd_user, new_resource.cmd_pass, new_resource.cmd_domain)
 
     new_resource.updated_by_last_action(true)
   else
@@ -72,6 +72,11 @@ def dsmod_group_cmd(group_dn, user_dn, option)
 end
 
 def is_member_of?(user_dn, group_dn)
-  check = Mixlib::ShellOut.new("dsget group  \"#{group_dn}\"  -members").run_command
+  check = CmdHelper.shell_out("dsget group  \"#{group_dn}\"  -members",
+                              new_resource.cmd_user, new_resource.cmd_pass, new_resource.cmd_domain)
   check.stdout.include?(user_dn)
+end
+
+def print_msg(action)
+  "windows_ad_group_member[#{action}]"
 end

--- a/providers/ou.rb
+++ b/providers/ou.rb
@@ -121,10 +121,8 @@ end
 
 def dn
   dn = "ou=#{new_resource.name},"
-  if new_resource.ou.nil?
-  else
-    dn << new_resource.ou.split("/").reverse.map! { |k| "ou=#{k}" }.join(",")
-    dn << ","
+  unless new_resource.ou.nil?
+    dn << new_resource.ou.split("/").reverse.map! { |k| "ou=#{k}" }.join(",") << ","
   end
   dn << new_resource.domain_name.split(".").map! { |k| "dc=#{k}" }.join(",")
 end

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -107,17 +107,10 @@ end
 def dn
   if new_resource.reverse == "true"
     name = new_resource.name.split(" ").reverse.map! { |k| k }.join("\\, ")
-    dn = "CN=#{name},"
   else
-    dn = "CN=#{new_resource.name},"
+    name = new_resource.name
   end
-  if new_resource.ou.downcase == 'users'
-    dn << "CN=#{new_resource.ou},"
-  else
-    dn << new_resource.ou.split("/").reverse.map! { |k| "OU=#{k}" }.join(",")
-    dn << ","
-  end
-  dn << new_resource.domain_name.split(".").map! { |k| "DC=#{k}" }.join(",")
+  CmdHelper.dn(name, new_resource.ou, new_resource.domain_name)
 end
 
 def exists?

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -38,7 +38,7 @@ action :create do
     cmd << dn
     cmd << "\""
 
-    cmd << cmd_options(new_resource.options)
+    cmd << CmdHelper.cmd_options(new_resource.options)
 
   execute "Create_#{new_resource.name}" do
     command cmd
@@ -54,7 +54,7 @@ action :modify do
     cmd << " user "
     cmd << dn
 
-    cmd << cmd_options(new_resource.options)
+    cmd << CmdHelper.cmd_options(new_resource.options)
 
     execute "Modify_#{new_resource.name}" do
       command cmd
@@ -72,7 +72,7 @@ action :move do
     cmd = "dsmove "
     cmd << dn
 
-    cmd << cmd_options(new_resource.options)
+    cmd << CmdHelper.cmd_options(new_resource.options)
 
     execute "Move_#{new_resource.name}" do
       command cmd
@@ -91,7 +91,7 @@ action :delete do
     cmd << dn
     cmd << " -noprompt"
 
-    cmd << cmd_options(new_resource.options)
+    cmd << CmdHelper.cmd_options(new_resource.options)
 
     execute "Create_#{new_resource.name}" do
       command cmd
@@ -102,15 +102,6 @@ action :delete do
     Chef::Log.debug("The object has already been removed")
     new_resource.updated_by_last_action(false)
   end
-end
-
-def cmd_options(options)
-  cmd = ''
-  options.each do |option, value|
-    cmd << " -#{option} \"#{value}\""
-    # [-subtree [-exclude]] [-noprompt] [{-s Server | -d Domain}] [-u UserName] [-p {Password | *}][-c][-q][{-uc | -uco | -uci}]
-  end
-  cmd
 end
 
 def dn

--- a/resources/computer.rb
+++ b/resources/computer.rb
@@ -32,3 +32,6 @@ attribute :name, :kind_of => String, :name_attribute => true
 attribute :domain_name, :kind_of => String
 attribute :ou, :kind_of => String
 attribute :options, :kind_of => Hash, :default => {}
+attribute :cmd_user, :kind_of => String
+attribute :cmd_pass, :kind_of => String
+attribute :cmd_domain, :kind_of => String

--- a/resources/contact.rb
+++ b/resources/contact.rb
@@ -32,3 +32,6 @@ attribute :name, :kind_of => String, :name_attribute => true
 attribute :domain_name, :kind_of => String
 attribute :ou, :kind_of => String
 attribute :options, :kind_of => Hash, :default => {}
+attribute :cmd_user, :kind_of => String
+attribute :cmd_pass, :kind_of => String
+attribute :cmd_domain, :kind_of => String

--- a/resources/group.rb
+++ b/resources/group.rb
@@ -32,3 +32,6 @@ attribute :name, :kind_of => String, :name_attribute => true
 attribute :domain_name, :kind_of => String
 attribute :ou, :kind_of => String
 attribute :options, :kind_of => Hash, :default => {}
+attribute :cmd_user, :kind_of => String
+attribute :cmd_pass, :kind_of => String
+attribute :cmd_domain, :kind_of => String

--- a/resources/group_member.rb
+++ b/resources/group_member.rb
@@ -33,3 +33,6 @@ attribute :group_name, :kind_of => String, :required => true
 attribute :domain_name, :kind_of => String
 attribute :user_ou, :kind_of => String
 attribute :group_ou, :kind_of => String
+attribute :cmd_user, :kind_of => String
+attribute :cmd_pass, :kind_of => String
+attribute :cmd_domain, :kind_of => String

--- a/resources/ou.rb
+++ b/resources/ou.rb
@@ -32,3 +32,6 @@ attribute :name, :kind_of => String, :name_attribute => true
 attribute :domain_name, :kind_of => String
 attribute :ou, :kind_of => String
 attribute :options, :kind_of => Hash, :default => {}
+attribute :cmd_user, :kind_of => String
+attribute :cmd_pass, :kind_of => String
+attribute :cmd_domain, :kind_of => String

--- a/resources/user.rb
+++ b/resources/user.rb
@@ -33,3 +33,6 @@ attribute :domain_name, :kind_of => String
 attribute :ou, :kind_of => String
 attribute :options, :kind_of => Hash, :default => {}
 attribute :reverse, :kind_of => String
+attribute :cmd_user, :kind_of => String
+attribute :cmd_pass, :kind_of => String
+attribute :cmd_domain, :kind_of => String

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,5 @@
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+end

--- a/spec/unit/cmd_helper_spec.rb
+++ b/spec/unit/cmd_helper_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+require_relative '../../libraries/cmd_helper'
+
+describe 'cmd_helper' do
+  describe '#cmd_options' do
+    it 'builds an empty string when there are no options' do
+      result = CmdHelper.cmd_options({})
+      
+      expect(result).to be_empty
+    end
+
+    it 'adds a minus to the options and wrapps the vlaues in double quotes' do
+      result = CmdHelper.cmd_options({'opt1' => 'val1', 'opt2' => 'val2'})
+      
+      expect(result).to eq(' -opt1 "val1" -opt2 "val2"')
+    end
+  end
+end

--- a/spec/unit/cmd_helper_spec.rb
+++ b/spec/unit/cmd_helper_spec.rb
@@ -15,4 +15,36 @@ describe 'cmd_helper' do
       expect(result).to eq(' -opt1 "val1" -opt2 "val2"')
     end
   end
+
+  describe '#dn' do
+    it 'builds a dn with a name, an OU and a domain' do
+      result = CmdHelper.dn('name', 'unit', 'domain')
+
+      expect(result).to eq('CN=name,OU=unit,DC=domain')
+    end
+
+    it 'splits composit OUs' do
+      result = CmdHelper.dn('name', 'unit/subunit', 'domain')
+
+      expect(result).to eq('CN=name,OU=subunit,OU=unit,DC=domain')
+    end
+
+    it 'splits composit domain names' do
+      result = CmdHelper.dn('name', 'unit', 'domain.local')
+
+      expect(result).to eq('CN=name,OU=unit,DC=domain,DC=local')
+    end
+
+    it 'handles users OU' do
+      result = CmdHelper.dn('name', 'users', 'domain')
+
+      expect(result).to eq('CN=name,CN=users,DC=domain')
+    end
+
+    it 'handles empty OUs' do
+      result = CmdHelper.dn('name', nil, 'domain')
+
+      expect(result).to eq('CN=name,DC=domain')
+    end
+  end
 end


### PR DESCRIPTION
chef-client in non domain controller boxes runs without enough privileges to interact with Active Directory. This breaks the chef-client run is a new AD object is to be created/deleted/modified.

With this change, the providers are enhanced with three more attributes that enable the shell_out command to run under a different account (that can possible have the right permissions to manage AD objects).

This PR addresses the issue reported in https://github.com/TAMUArch/cookbook.windows_ad/issues/35

Other commits bundled together in this PR reduce code duplication (b7ed396, 44da8e0) and improve the use of conditionals (f8f5d94).
The PR includes an RSpec test file that checks the proper creation of distinguished names (to run it do a `rspec spec/` command)