### PR TITLE
Add support for more AD containers

### DIFF
--- a/libraries/cmd_helper.rb
+++ b/libraries/cmd_helper.rb
@@ -11,9 +11,11 @@ class CmdHelper
   end
 
   def self.dn(name, ou, domain)
+    containers = [ 'users', 'builtin', 'computers', 'foreignsecurityprincipals', 'managed service accounts' ]
+    
     dn = "CN=#{name},"
     unless ou.nil?
-      if ou.downcase == 'users'
+      if containers.include? ou.downcase
         dn << "CN=#{ou},"
       else
         dn << ou.split("/").reverse.map! { |k| "OU=#{k}" }.join(",") << ","

--- a/spec/unit/cmd_helper_spec.rb
+++ b/spec/unit/cmd_helper_spec.rb
@@ -35,10 +35,34 @@ describe 'cmd_helper' do
       expect(result).to eq('CN=name,OU=unit,DC=domain,DC=local')
     end
 
-    it 'handles users OU' do
+    it 'handles users container' do
       result = CmdHelper.dn('name', 'users', 'domain')
 
       expect(result).to eq('CN=name,CN=users,DC=domain')
+    end
+
+    it 'handles builtin container' do
+      result = CmdHelper.dn('name', 'Builtin', 'domain')
+
+      expect(result).to eq('CN=name,CN=Builtin,DC=domain')
+    end
+
+    it 'handles computers container' do
+      result = CmdHelper.dn('name', 'Computers', 'domain')
+
+      expect(result).to eq('CN=name,CN=Computers,DC=domain')
+    end
+
+    it 'handles foreign security principals container' do
+      result = CmdHelper.dn('name', 'ForeignSecurityPrincipals', 'domain')
+
+      expect(result).to eq('CN=name,CN=ForeignSecurityPrincipals,DC=domain')
+    end
+
+    it 'handles managed service accounts container' do
+      result = CmdHelper.dn('name', 'managed service accounts', 'domain')
+
+      expect(result).to eq('CN=name,CN=managed service accounts,DC=domain')
     end
 
     it 'handles empty OUs' do


### PR DESCRIPTION
When computing the distinguished name of an AD object, the cookbook was already handling the Users container. However there are more such containers that can be used and the computation of distinguished names should support that. Otherwise it will no be possible to add/modify/delete in those containers.

This PR addresses issue https://github.com/TAMUArch/cookbook.windows_ad/issues/40 by adding support for the Builtin, Computers, ForeignSecurityPrincipals and Managed Service Accounts.



