### PR TITLE
Decompose nested OUs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ Gemfile.lock
 options.txt
 recipes/contoso.rb
 Vagrantfile
+/.zero-knife.rb
+/test/fixtures/cookbooks/

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Requirements
 Platform
 --------
 
-* Windows Server 2008 R2 
+* Windows Server 2008 R2
 * Windows Server 2012 Family
 
 Cookbooks
@@ -19,7 +19,7 @@ Cookbooks
 Usage
 ==========
 #### windows_ad::default
-The windows_ad::default recipe installs the required roles and features to support a domain controller. 
+The windows_ad::default recipe installs the required roles and features to support a domain controller.
 
 ```json
 {
@@ -61,7 +61,7 @@ Resource/Provider
       type "forest"
       safe_mode_pass "Passw0rd"
     end
-    
+
     # Create Contoso.com replica
     windows_ad_domain "contoso.com" do
       action :create
@@ -91,20 +91,20 @@ Resource/Provider
                  "InstallDNS" => nil
                })
     end
-    
+
     # Remove Domain Controller
     windows_ad_domain "contoso.com" do
       action :delete
       local_pass "Passw0rd"
     end
-    
+
     # Join Contoso.com domain
     windows_ad_domain "contoso.com" do
       action :join
       domain_pass "Passw0rd"
       domain_user "Administrator"
     end
-    
+
     # Unjoin Contoso.com domain
     windows_ad_domain "contoso.com" do
       action :unjoin
@@ -140,7 +140,7 @@ Resource/Provider
       domain_name "contoso.com"
       ou "computers"
     end
-    
+
     # Create computer "workstation1" in the Computers OU with description of "Computer"
     windows_ad_computer "workstation1" do
       action :create
@@ -186,7 +186,7 @@ Resource/Provider
       action :create
       domain_name "contoso.com"
       ou "users"
-      options ({ "fn" => "Bob", 
+      options ({ "fn" => "Bob",
                  "ln" => "Smith"
                })
     end
@@ -197,14 +197,14 @@ Resource/Provider
       action :create
       domain_name "contoso.com"
       ou "users"
-      options ({ "fn" => "Bob", 
+      options ({ "fn" => "Bob",
                  "ln" => "Smith"
                })
       cmd_user "Administrator"
       cmd_pass "password"
       cmd_domain "contoso.com"
     end
-    
+
 `group`
 -------
 
@@ -233,7 +233,7 @@ Resource/Provider
       domain_name "contoso.com"
       ou "users"
     end
-    
+
     # Create group "IT" in the Users OU with Description "Information Technology Security Group"
     windows_ad_group "IT" do
       action :create
@@ -252,7 +252,7 @@ Resource/Provider
       cmd_pass "password"
       cmd_domain "contoso.com"
     end
-    
+
 `ou`
 ----
 
@@ -280,7 +280,7 @@ Resource/Provider
       action :create
       domain_name "contoso.com"
     end
-    
+
     # Create Organizational Unit "IT" in the "Department" OUroot
     windows_ad_ou "IT" do
       action :create
@@ -296,7 +296,7 @@ Resource/Provider
       cmd_pass "password"
       cmd_domain "contoso.com"
     end
-    
+
 `users`
 -------
 
@@ -392,7 +392,15 @@ Resource/Provider
       cmd_pass "password"
       cmd_domain "contoso.com"
     end
-    
+
+
+Testing
+=======
+
+The libraries provided with the cookbook can be tested using RSpec and the tests in `spec/`.
+```bash
+rspec spec/
+```
 
 Contributing
 ============
@@ -408,7 +416,7 @@ License and Authors
 ===================
 
 Authors:: Derek Groh (<dgroh@arch.tamu.edu>)
-          Richard Guin          
+          Richard Guin
           Miroslav Kyurchev (<mkyurchev@gmail.com>)
 		  Matt Wrock (<matt@mattwrock.com>)
 		  Miguel Ferreira (<miguelferreira@me.com>)

--- a/libraries/cmd_helper.rb
+++ b/libraries/cmd_helper.rb
@@ -12,16 +12,28 @@ class CmdHelper
 
   def self.dn(name, ou, domain)
     containers = [ 'users', 'builtin', 'computers', 'foreignsecurityprincipals', 'managed service accounts' ]
-    
+
     dn = "CN=#{name},"
     unless ou.nil?
       if containers.include? ou.downcase
         dn << "CN=#{ou},"
       else
-        dn << ou.split("/").reverse.map! { |k| "OU=#{k}" }.join(",") << ","
+        dn << ou_partial_dn(ou) << ','
       end
     end
-    dn << domain.split(".").map! { |k| "DC=#{k}" }.join(",")
+    dn << dc_partial_dn(domain)
+  end
+
+  def self.ou_partial_dn(ou)
+    (ou || '').split('/').reverse.map! { |k| "OU=#{k}" }.join(',')
+  end
+
+  def self.dc_partial_dn(domain)
+    (domain || '').split(".").map! { |k| "DC=#{k}" }.join(',')
+  end
+
+  def self.ou_leaf(ou)
+    (ou || '').split('/').reverse.first || ''
   end
 
   def self.shell_out(cmd, user, pass, domain)
@@ -32,4 +44,5 @@ class CmdHelper
     end
     shellout
   end
+
 end

--- a/providers/group_member.rb
+++ b/providers/group_member.rb
@@ -2,7 +2,7 @@
 # Author:: Miguel Ferreira (<miguelferreira@me.com>)
 # Cookbook Name:: windows_ad
 # Provider:: group_member
-# 
+#
 # Copyright 2015, Schuberg Philis B.V.
 #
 # Permission is hereby granted, free of charge, to any person obtaining

--- a/spec/unit/cmd_helper_spec.rb
+++ b/spec/unit/cmd_helper_spec.rb
@@ -5,13 +5,13 @@ describe 'cmd_helper' do
   describe '#cmd_options' do
     it 'builds an empty string when there are no options' do
       result = CmdHelper.cmd_options({})
-      
+
       expect(result).to be_empty
     end
 
     it 'adds a minus to the options and wrapps the vlaues in double quotes' do
       result = CmdHelper.cmd_options({'opt1' => 'val1', 'opt2' => 'val2'})
-      
+
       expect(result).to eq(' -opt1 "val1" -opt2 "val2"')
     end
   end
@@ -69,6 +69,72 @@ describe 'cmd_helper' do
       result = CmdHelper.dn('name', nil, 'domain')
 
       expect(result).to eq('CN=name,DC=domain')
+    end
+  end
+
+  describe '#ou_partial_dn' do
+    it 'returns an empty string when given a nil value' do
+      result = CmdHelper.ou_partial_dn(nil)
+      expect(result).to eq('')
+    end
+
+    it 'returns an empty string when given an empty string' do
+      result = CmdHelper.ou_partial_dn('')
+      expect(result).to eq('')
+    end
+
+    it 'handles single OUs' do
+      result = CmdHelper.ou_partial_dn('ou')
+      expect(result).to eq('OU=ou')
+    end
+
+    it 'handles nested OUs' do
+      result = CmdHelper.ou_partial_dn('ou1/ou2')
+      expect(result).to eq('OU=ou2,OU=ou1')
+    end
+  end
+
+  describe '#domain_partial_dn' do
+    it 'returns an empty string when given a nil value' do
+      result = CmdHelper.dc_partial_dn(nil)
+      expect(result).to eq('')
+    end
+
+    it 'returns an empty string when given an empty string' do
+      result = CmdHelper.dc_partial_dn('')
+      expect(result).to eq('')
+    end
+
+    it 'handles simple domains' do
+      result = CmdHelper.dc_partial_dn('domain')
+      expect(result).to eq('DC=domain')
+    end
+
+    it 'handles nested domains' do
+      result = CmdHelper.dc_partial_dn('domain.local')
+      expect(result).to eq('DC=domain,DC=local')
+    end
+  end
+
+  describe '#ou_leaf' do
+    it 'returns an empty string when given a nil value' do
+      result = CmdHelper.ou_leaf(nil)
+      expect(result).to eq('')
+    end
+
+    it 'returns an empty string when given an empty string' do
+      result = CmdHelper.ou_leaf('')
+      expect(result).to eq('')
+    end
+
+    it 'handles single OUs' do
+      result = CmdHelper.ou_leaf('ou')
+      expect(result).to eq('ou')
+    end
+
+    it 'handles nested OUs' do
+      result = CmdHelper.ou_leaf('ou1/ou2')
+      expect(result).to eq('ou2')
     end
   end
 end


### PR DESCRIPTION
When checking for OUs, decompose nested OUs to check for the "leaf".
Also use library methods that consistently build partial distinguished
names for OUs and domains.

This PR partly addresses issue https://github.com/TAMUArch/cookbook.windows_ad/issues/42

There are some changes that are simply the removal of trailing white spaces (sorry for not separating those).