### PR TITLE
Make distinguished names string comparisons case-insensitive

### DIFF
--- a/providers/computer.rb
+++ b/providers/computer.rb
@@ -2,7 +2,7 @@
 # Author:: Derek Groh (<dgroh@arch.tamu.edu>)
 # Cookbook Name:: windows_ad
 # Provider:: computer
-# 
+#
 # Copyright 2013, Texas A&M
 #
 # Permission is hereby granted, free of charge, to any person obtaining
@@ -68,7 +68,7 @@ action :move do
     cmd = "dsmove "
     cmd << CmdHelper.dn(new_resource.name, new_resource.ou, new_resource.domain_name)
 
-    cmd << CmdHelper.cmd_options(new_resource.options) 
+    cmd << CmdHelper.cmd_options(new_resource.options)
 
     Chef::Log.info(print_msg("move #{new_resource.name}"))
     CmdHelper.shell_out(cmd, new_resource.cmd_user, new_resource.cmd_pass, new_resource.cmd_domain)
@@ -86,7 +86,7 @@ action :delete do
     cmd << CmdHelper.dn(new_resource.name, new_resource.ou, new_resource.domain_name)
     cmd << " -noprompt"
 
-    cmd << CmdHelper.cmd_options(new_resource.options) 
+    cmd << CmdHelper.cmd_options(new_resource.options)
 
     Chef::Log.info(print_msg("delete #{new_resource.name}"))
     CmdHelper.shell_out(cmd, new_resource.cmd_user, new_resource.cmd_pass, new_resource.cmd_domain)
@@ -94,14 +94,14 @@ action :delete do
     new_resource.updated_by_last_action(true)
   else
     Chef::Log.debug("The object has already been removed")
-    new_resource.updated_by_last_action(false)  
+    new_resource.updated_by_last_action(false)
   end
 end
 
 def exists?
   check = CmdHelper.shell_out("dsquery computer -name \"#{new_resource.name}\"",
                               new_resource.cmd_user, new_resource.cmd_pass, new_resource.cmd_domain)
-  check.stdout.include? "DC"
+  check.stdout.downcase.include? "dc"
 end
 
 def print_msg(action)

--- a/providers/contact.rb
+++ b/providers/contact.rb
@@ -2,7 +2,7 @@
 # Author:: Derek Groh (<dgroh@arch.tamu.edu>)
 # Cookbook Name:: windows_ad
 # Provider:: contact
-# 
+#
 # Copyright 2013, Texas A&M
 #
 # Permission is hereby granted, free of charge, to any person obtaining
@@ -105,7 +105,7 @@ def exists?
                                 new_resource.cmd_user, new_resource.cmd_pass, new_resource.cmd_domain)
   user = CmdHelper.shell_out("dsquery user -name #{new_resource.name}",
                              new_resource.cmd_user, new_resource.cmd_pass, new_resource.cmd_domain)
-  contact.stdout.include? "DC" or user.stdout.include? "DC"
+  contact.stdout.downcase.include? "dc" or user.stdout.downcase.include? "dc"
 end
 
 def print_msg(action)

--- a/providers/domain.rb
+++ b/providers/domain.rb
@@ -133,7 +133,7 @@ end
 
 def computer_exists?
   comp = Mixlib::ShellOut.new("powershell.exe -command \"get-wmiobject -class win32_computersystem -computername . | select domain\"").run_command
-  comp.stdout.include?(new_resource.name) or comp.stdout.include?(new_resource.name.upcase)
+  comp.stdout.downcase.include?(new_resource.downcase.name) or comp.stdout.downcase.include?(new_resource.downcase.name.upcase)
 end
 
 def last_dc?

--- a/providers/group.rb
+++ b/providers/group.rb
@@ -2,7 +2,7 @@
 # Author:: Derek Groh (<dgroh@arch.tamu.edu>)
 # Cookbook Name:: windows_ad
 # Provider:: group
-# 
+#
 # Copyright 2013, Texas A&M
 #
 # Permission is hereby granted, free of charge, to any person obtaining
@@ -53,7 +53,7 @@ action :modify do
     cmd << " group "
     cmd << CmdHelper.dn(new_resource.name, new_resource.ou, new_resource.domain_name)
 
-    cmd << CmdHelper.cmd_options(new_resource.options) 
+    cmd << CmdHelper.cmd_options(new_resource.options)
 
     Chef::Log.info(print_msg("modify #{new_resource.name}"))
     CmdHelper.shell_out(cmd, new_resource.cmd_user, new_resource.cmd_pass, new_resource.cmd_domain)
@@ -96,13 +96,13 @@ action :delete do
     new_resource.updated_by_last_action(true)
   else
     Chef::Log.debug("The object has already been removed")
-    new_resource.updated_by_last_action(false)  
+    new_resource.updated_by_last_action(false)
   end
 end
 
 def exists?
   check = Mixlib::ShellOut.new("dsquery group -name \"#{new_resource.name}\"").run_command
-  check.stdout.include? "DC"
+  check.stdout.downcase.include? "dc"
 end
 
 def print_msg(action)

--- a/providers/group_member.rb
+++ b/providers/group_member.rb
@@ -2,7 +2,7 @@
 # Author:: Miguel Ferreira (<miguelferreira@me.com>)
 # Cookbook Name:: windows_ad
 # Provider:: group_member
-# 
+#
 # Copyright 2015, Schuberg Philis B.V.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
@@ -74,7 +74,7 @@ end
 def is_member_of?(user_dn, group_dn)
   check = CmdHelper.shell_out("dsget group  \"#{group_dn}\"  -members",
                               new_resource.cmd_user, new_resource.cmd_pass, new_resource.cmd_domain)
-  check.stdout.include?(user_dn)
+  check.stdout.downcase.include?(user_dn.downcase)
 end
 
 def print_msg(action)

--- a/providers/ou.rb
+++ b/providers/ou.rb
@@ -2,7 +2,7 @@
 # Author:: Derek Groh (<dgroh@arch.tamu.edu>)
 # Cookbook Name:: windows_ad
 # Provider:: ou
-# 
+#
 # Copyright 2013, Texas A&M
 #
 # Permission is hereby granted, free of charge, to any person obtaining
@@ -130,7 +130,7 @@ def parent?
                                  new_resource.cmd_user, new_resource.cmd_pass, new_resource.cmd_domain)
     path = "OU=#{new_resource.ou},"
     path << ldap
-    parent.stdout.include? path
+    parent.stdout.downcase.include? path.downcase
   end
 end
 def exists?
@@ -144,7 +144,7 @@ def exists?
                               new_resource.cmd_user, new_resource.cmd_pass, new_resource.cmd_domain)
   path = "OU=#{new_resource.name},"
   path << ldap
-  check.stdout.include? path
+  check.stdout.downcase.include? path.downcase
 end
 
 def print_msg(action)

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -115,11 +115,11 @@ def exists?
     reverse_name = new_resource.name.split(" ").reverse.map! { |k| k }.join(", ")
     contact = CmdHelper.shell_out("dsquery contact -name \"#{reverse_name}\"", cmd_user, cmd_pass, cmd_domain)
     user = CmdHelper.shell_out("dsquery user -name \"#{reverse_name}\"", cmd_user, cmd_pass, cmd_domain)
-    contact.stdout.include? "DC" or user.stdout.include? "DC"
+    contact.stdout.downcase.include? "dc" or user.stdout.downcase.include? "dc"
   else
     contact = CmdHelper.shell_out("dsquery contact -name \"#{new_resource.name}\"", cmd_user, cmd_pass, cmd_domain)
     user = CmdHelper.shell_out("dsquery user -name \"#{new_resource.name}\"", cmd_user, cmd_pass, cmd_domain)
-    contact.stdout.include? "DC" or user.stdout.include? "DC"
+    contact.stdout.downcase.include? "dc" or user.stdout.downcase.include? "dc"
   end
 end
 


### PR DESCRIPTION
This PR makes string comparisons case insensitive to follow the windows general rule of case-insensitiveness.
It addresses the issue reported in https://github.com/TAMUArch/cookbook.windows_ad/issues/44

Excuses for the mixed-in removals of trailing white spaces.