### PR TITLE
Testing with vagrant

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,11 @@
+source "https://supermarket.getchef.com"
+
+group :deps do
+  cookbook 'windows'
+end
+
+group :integration do
+  cookbook 'test_windows_ad', path: 'test/fixtures/test_cookbooks/test_windows_ad'
+end
+
+metadata

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,59 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+standard_box = ENV['VAGRANT_TEST_BOX']
+
+test_machines = {
+  'test-dc' => {
+    'box'      => standard_box,
+    'ip'       => '192.168.56.5',
+    'run_list' => [ 'recipe[test_windows_ad::setup_dc]' ]
+  },
+  'test-dm' => {
+    'box'      => standard_box,
+    'ip'       => '192.168.56.7',
+    'run_list' => [ 'recipe[test_windows_ad::join_domain]' ]
+  }
+}
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |global_config|
+  test_machines.each_pair do |name, options|
+    global_config.vm.define name do |config|
+
+      config.vm.hostname = name
+      config.vm.box      = options['box']
+
+      config.vm.communicator = 'winrm'
+      config.vm.guest        = :windows
+
+      config.vm.network 'private_network', ip: options['ip'], virtualbox__intnet: 'windows_ad'
+
+      config.vm.provider 'virtualbox' do |vb|
+        vb.gui = false
+        vb.customize ['modifyvm', :id, "--nicpromisc1", "allow-all" ]
+        vb.customize ['modifyvm', :id, "--nicpromisc2", "allow-all" ]
+      end
+
+      config.berkshelf.enabled = true
+
+      config.omnibus.chef_version = 'latest'
+
+      config.vm.provision 'chef_client', run: 'always' do |chef|
+        chef.log_level = 'info'
+
+        chef.custom_config_path = 'Vagrantfile.chef'
+        chef.file_cache_path    = 'c:/var/chef/cache'
+
+        chef.run_list = options['run_list']
+
+        # You may also specify custom JSON attributes:
+        chef.json = {
+          'windows_ad' => { 'dc_ip' => '192.168.56.5' }
+        }
+      end
+    end
+  end
+end

--- a/Vagrantfile.chef
+++ b/Vagrantfile.chef
@@ -1,0 +1,1 @@
+Chef::Config.ssl_verify_mode = :verify_peer

--- a/chefignore
+++ b/chefignore
@@ -1,0 +1,12 @@
+*file
+*file.lock
+bin
+bundle
+chefignore
+spec
+test
+vendor
+.git
+.*
+dev.*
+*_dev

--- a/test/fixtures/test_cookbooks/test_windows_ad/libraries/windows_helper.rb
+++ b/test/fixtures/test_cookbooks/test_windows_ad/libraries/windows_helper.rb
@@ -1,0 +1,15 @@
+class WindowsHelper
+  if RUBY_PLATFORM =~ /mswin|mingw32|windows/
+    require 'win32ole'
+    @@wmi = WIN32OLE.connect("winmgmts://")
+  end
+
+  def self.nic_interface_indexes
+    indexes = []
+    nics = @@wmi.ExecQuery("Select * from Win32_NetworkAdapter Where NetConnectionStatus = 2")
+    nics.each do |nic|
+      indexes << nic.interfaceindex
+    end
+    indexes
+  end
+end

--- a/test/fixtures/test_cookbooks/test_windows_ad/metadata.rb
+++ b/test/fixtures/test_cookbooks/test_windows_ad/metadata.rb
@@ -1,0 +1,5 @@
+name             'test_windows_ad'
+description      'Tests windows_ad'
+version          '0.1.0'
+
+depends          'windows_ad'

--- a/test/fixtures/test_cookbooks/test_windows_ad/recipes/join_domain.rb
+++ b/test/fixtures/test_cookbooks/test_windows_ad/recipes/join_domain.rb
@@ -1,0 +1,47 @@
+%w(RSAT-AD-PowerShell RSAT-AD-Tools RSAT-ADDS RSAT-AD-AdminCenter).each do |feature|
+  windows_feature feature do
+    all      true
+    provider Chef::Provider::WindowsFeaturePowershell
+    action :install
+  end
+end
+
+short_domain = node.hostname[0..3].downcase
+domain = "#{short_domain}.local"
+dc_ip  = node['windows_ad']['dc_ip'] || search(:node, "recipe:test_windows_ad\\:\\:setup_dc")[0]['ipaddress']
+
+puts "DEBUG:: IP => #{dc_ip}"
+
+WindowsHelper.nic_interface_indexes.each do |index|
+  powershell_script "set DNS servers for NIC #{index}" do
+    code "Set-DNSClientServerAddress -interfaceIndex #{index} -ServerAddresses (\"#{dc_ip}\",\"8.8.8.8\")"
+  end
+end
+
+admin = 'Administrator'
+admin_pass = 'Password1234###!'
+
+execute "net user \"#{admin}\" \"#{admin_pass}\""
+
+windows_ad_domain domain do
+  action :join
+  domain_user admin
+  domain_pass admin_pass
+end
+
+domain_admin = "#{short_domain}\\#{admin}"
+execute "net localgroup \"Administrators\" \"#{domain_admin}\" /add" do
+  not_if "net localgroup Administrators | grep -i #{admin} | grep -i #{short_domain}"
+end
+
+windows_ad_user 'User3' do
+  domain_name domain
+  ou 'Users'
+  options ({
+    'pwd' => 'Password5673#'
+  })
+  cmd_user   admin
+  cmd_pass   admin_pass
+  cmd_domain short_domain
+  action :create
+end

--- a/test/fixtures/test_cookbooks/test_windows_ad/recipes/setup_dc.rb
+++ b/test/fixtures/test_cookbooks/test_windows_ad/recipes/setup_dc.rb
@@ -1,0 +1,86 @@
+%w(AD-Domain-Services RSAT-AD-PowerShell RSAT-AD-Tools RSAT-ADDS RSAT-AD-AdminCenter).each do |feature|
+  windows_feature feature do
+    all      true
+    provider Chef::Provider::WindowsFeaturePowershell
+    action :install
+  end
+end
+
+user = 'Administrator'
+pass = 'Password1234###!'
+domain = "#{node.hostname[0..3].downcase}.local"
+
+execute "net user \"#{user}\" \"#{pass}\""
+
+windows_ad_domain domain do
+  type           'forest'
+  safe_mode_pass pass
+  domain_pass    pass
+  domain_user    user
+  action :create
+end
+
+windows_ad_ou 'AD' do
+  domain_name domain
+  action :create
+end
+
+windows_ad_ou 'Groups' do
+  domain_name domain
+  ou          'AD'
+  action :create
+end
+
+windows_ad_ou 'SubGroups' do
+  domain_name domain
+  ou          'AD/Groups'
+  action :create
+end
+
+windows_ad_group 'Group1' do
+  domain_name domain
+  ou 'AD/Groups'
+  action :create
+end
+
+windows_ad_user 'User1' do
+  domain_name domain
+  ou 'Users'
+  options ({
+    'pwd' => pass
+  })
+  action :create
+end
+
+windows_ad_user 'User2' do
+  domain_name domain
+  ou 'Users'
+  options ({
+    'pwd' => pass
+  })
+  action :create
+end
+
+windows_ad_group_member 'User1' do
+  domain_name domain
+  group_name 'Group1'
+  user_ou  'Users'
+  group_ou 'AD/Groups'
+  action :add
+end
+
+windows_ad_group_member 'User2' do
+  domain_name domain
+  group_name 'Group1'
+  user_ou  'Users'
+  group_ou 'AD/Groups'
+  action :add
+end
+
+windows_ad_group_member 'User1' do
+  domain_name domain
+  group_name 'Group1'
+  user_ou  'Users'
+  group_ou 'AD/Groups'
+  action :remove
+end


### PR DESCRIPTION
I'm contributing back a Vagrantfile (with the respective configuration, fixtures, test cookbook and documentation) that I have been using to test this cookbook.
Testing is not complete in the sense that I do not exercise all the providers and recipes in the cookbook, and also because I do not do any assertions (i.e. checks) on the converged system.
As of now the test passes if it can converge a domain controller, converge a domain member (that joins the domain), create a few entities in AD.

I've documented the procedure in the README file.
Once we have this in place I can explore possibilities for hooking our PRs with a travis build.
This way new PRs would automatically get feedback from travis on the respective github page.