### PR TITLE
Add restart parameter (fixes TAMUArch/cookbook.windows_ad#12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,14 @@ Resource/Provider
       domain_user "Administrator"
     end
 
+    # Join Contoso.com domain without restart
+    windows_ad_domain "contoso.com" do
+      action :join
+      domain_pass "Passw0rd"
+      domain_user "Administrator"
+      restart false
+    end
+
     # Join Contoso.com domain with OU
     windows_ad_domain "contoso.com" do
       action :join
@@ -119,6 +127,14 @@ Resource/Provider
       action :unjoin
       domain_pass "Passw0rd"
       domain_user "Administrator"
+    end
+
+    # Unjoin Contoso.com domain without restart
+    windows_ad_domain "contoso.com" do
+      action :unjoin
+      domain_pass "Passw0rd"
+      domain_user "Administrator"
+      restart false
     end
 
 `computer`

--- a/resources/domain.rb
+++ b/resources/domain.rb
@@ -31,6 +31,7 @@ default_action :create
 attribute :name, :kind_of => String, :name_attribute => true
 attribute :domain_user, :kind_of => String, :required => true
 attribute :domain_pass, :kind_of => String, :required => true
+attribute :restart, :kind_of => [TrueClass, FalseClass], :required => true, :default => true
 attribute :type, :kind_of => String, :default => "forest"
 attribute :safe_mode_pass, :kind_of => String, :required => true
 attribute :options, :kind_of => Hash, :default => {}


### PR DESCRIPTION
Allows people to skip the immediate restart if they prefer.  Providers will still do the restart by default so original behaviour is not modified if the `restart` attribute isn't specified.