### PR TITLE
fixing issue where powershell requires quotes around OU

### DIFF
--- a/providers/domain.rb
+++ b/providers/domain.rb
@@ -101,7 +101,7 @@ action :join do
           EOH
         else
           cmd_text = "netdom join #{node[:hostname]} /d #{new_resource.name} /ud:#{new_resource.domain_user} /pd:#{new_resource.domain_pass}"
-          cmd_text << " /ou:#{ou_dn}" if new_resource.ou
+          cmd_text << " /ou:\"#{ou_dn}\"" if new_resource.ou
           cmd_text << " /reboot" if new_resource.restart
           code "#{cmd_text}"
         end


### PR DESCRIPTION
Hi, I've never contributed to a project like this before, but I found a bug in the domain provider code when running on a clean windows 2008 r2 box. The chef error didn't provide much information:

![image](https://cloud.githubusercontent.com/assets/4236751/10027871/5c369c9c-6137-11e5-8fc5-7d58da0f1745.png)

It was trying to run a powershell script that looked like:
netdom join PC-NAME /d domain.name /ud:username /pd:password /ou:OU=OUNAME,DC=domain,DC=name /reboot

This works in cmd but not powershell. I found I could get it to work in powershell by wrapping the OU in quotes like:
netdom join PC-NAME /d domain.name /ud:username /pd:password /ou:"OU=OUNAME,DC=domain,DC=name" /reboot

