### PR TITLE
Fix Domain :join error if domain exists.  Change exists? to use dcdiag.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,7 +24,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
-if node[:os_version] >= "6.2"
+if node['os_version'] >= "6.2"
   [
     "Microsoft-Windows-GroupPolicy-ServerAdmintools-Update",
     "ServerManager-Core-RSAT",


### PR DESCRIPTION
This is the pull request to resolve issue #62 (Domain :join was erroring if domain existed rather than not existed).  

During this work I noticed that the original "exists?" method was unreliable as it did not consider AD Sites so I was getting "false" because the nodes cannot connect to DCs in all other sites.   I've changed this to use DCDiag as this seems the most reliable way of getting a correct response.

I've also included some rubocop and foodcritic fixes.

NB: I'm still downloading the windows 2012 VM so haven't completed the testing yet but wanted to get the PR up
