### PR TITLE
Use chef reboot resource to manage reboots

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Resource/Provider
 - domain_pass: User password to join the domain or to create a domain controller. **Required**: for `:create` except on `type` `forest` on windows 2012 and above.
 - local_pass: Local Administrator Password for removing domain controller.
 - replica_type: For Windows Server 2008, specifies installing new or additional domain controller.  Valid values: domain, replica.
+- restart: When creating or joining a domain whether to restart the computer.  Valid values: true, false.
+- restart_now: When creating or joining a domain and `restart` is set to `true`, whether to restart immediately or at the end of the Chef run.  Valid values: true, false.
 - ou: When joining to a domain, specify the OU to place the computer in. *Optional*
 - options: additional options as needed by AD DS Deployment http://technet.microsoft.com/en-us/library/cc732887.aspx for Windows Server 2008 and http://technet.microsoft.com/en-us/library/hh974719.aspx for Windows Server 2012.  Single parameters use nil for key value, see example below.
 
@@ -112,6 +114,14 @@ Resource/Provider
       domain_pass "Passw0rd"
       domain_user "Administrator"
       restart false
+    end
+
+    # Join Contoso.com domain, reboot at the end of the Chef run
+    windows_ad_domain "contoso.com" do
+      action :join
+      domain_pass "Passw0rd"
+      domain_user "Administrator"
+      restart_now false
     end
 
     # Join Contoso.com domain with OU

--- a/providers/domain.rb
+++ b/providers/domain.rb
@@ -43,7 +43,7 @@ action :create do
       cmd = "dcpromo -unattend"
       cmd << " -newDomain:#{new_resource.type}"
       cmd << " -NewDomainDNSName:#{new_resource.name}"
-      cmd << " -RebootOnCompletion:Yes"
+      cmd << " -RebootOnCompletion:No"
       cmd << " -SafeModeAdminPassword:(convertto-securestring '#{new_resource.safe_mode_pass}' -asplaintext -Force)"
       cmd << " -ReplicaOrNewDomain:#{new_resource.replica_type}"
     end
@@ -53,6 +53,13 @@ action :create do
     powershell_script "create_domain_#{new_resource.name}" do
       code cmd
       returns [0, 1, 2, 3]
+    end
+
+    # Reboot computer immediately or at end of chef run if restart is true
+    reboot 'Complete domain create' do
+      reason "Reboot after domain create by Chef."
+      action new_resource.restart_now ? :reboot_now : :request_reboot
+      only_if { new_resource.restart }
     end
 
     new_resource.updated_by_last_action(true)
@@ -94,7 +101,6 @@ action :join do
         if node[:os_version] >= "6.2"
           cmd_text = "Add-Computer -DomainName #{new_resource.name} -Credential $mycreds -Force:$true"
           cmd_text << " -OUPath '#{ou_dn}'" if new_resource.ou
-          cmd_text << " -Restart" if new_resource.restart
           code <<-EOH
             $secpasswd = ConvertTo-SecureString '#{new_resource.domain_pass}' -AsPlainText -Force
             $mycreds = New-Object System.Management.Automation.PSCredential  ('#{new_resource.name}\\#{new_resource.domain_user}', $secpasswd)
@@ -103,10 +109,17 @@ action :join do
         else
           cmd_text = "netdom join #{node[:hostname]} /d #{new_resource.name} /ud:#{new_resource.domain_user} /pd:#{new_resource.domain_pass}"
           cmd_text << " /ou:\"#{ou_dn}\"" if new_resource.ou
-          cmd_text << " /reboot" if new_resource.restart
           code "#{cmd_text}"
         end
       end
+
+      # Reboot computer immediately or at end of chef run if restart is true
+      reboot 'Complete domain join' do
+        reason "Reboot after domain join by Chef."
+        action new_resource.restart_now ? :reboot_now : :request_reboot
+        only_if { new_resource.restart }
+      end
+
       new_resource.updated_by_last_action(true)
     end
   end
@@ -145,7 +158,7 @@ end
 def computer_exists?
   comp = Mixlib::ShellOut.new("powershell.exe -command \"get-wmiobject -class win32_computersystem -computername . | select domain\"").run_command
   stdout = comp.stdout.downcase
-  stdout.include?(new_resource.name.downcase) 
+  stdout.include?(new_resource.name.downcase)
 end
 
 def last_dc?

--- a/resources/domain.rb
+++ b/resources/domain.rb
@@ -31,7 +31,8 @@ default_action :create
 attribute :name, :kind_of => String, :name_attribute => true
 attribute :domain_user, :kind_of => String, :required => true
 attribute :domain_pass, :kind_of => String, :required => true
-attribute :restart, :kind_of => [TrueClass, FalseClass], :required => true, :default => true
+attribute :restart, :kind_of => [TrueClass, FalseClass], :required => false, :default => true
+attribute :restart_now, :kind_of => [TrueClass, FalseClass], :required => false, :default => true
 attribute :type, :kind_of => String, :default => "forest"
 attribute :safe_mode_pass, :kind_of => String, :required => true
 attribute :options, :kind_of => Hash, :default => {}


### PR DESCRIPTION
This changes some `windows_ad_domain` actions to use the Chef reboot resource.

You can also set `restart_now` to either `true` or `false`; `true` will reboot immediately, `false` will reboot at the end of a Chef run.  This option defaults to `true`.

The `restart` attribute is no longer required, it will default to `true`.