### PR TITLE
lock windows cookbook to 1.38.2 for win2008 family feature support

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,4 +6,4 @@ description      'Installs/Configures windows active directory'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.4.4'
 supports         'windows', ">= 6.1"
-depends          'windows'
+depends          'windows', "~> 1.38.2"


### PR DESCRIPTION
https://github.com/chef-cookbooks/windows/pull/294 introduced changes to the windows_feature to force powershell and Install-WindowsFeature which is not supported on Server 2008 Family.

Locking depends version to 1.38.2 until a decision can be made on best course of action.