### PR TITLE
#71 - Add doublequote missing to modify user

### DIFF
--- a/providers/user.rb
+++ b/providers/user.rb
@@ -50,6 +50,7 @@ action :modify do
   if exists?
     cmd = 'dsmod'
     cmd << ' user '
+    cmd << "\""    
     cmd << dn
     cmd << "\""
     cmd << CmdHelper.cmd_options(new_resource.options)


### PR DESCRIPTION
It was missing just one line for surrounded the dn variable in order to update Ad User.