### PR TITLE
Fix incorrect Windows version identification for Windows 2008 R2

### DIFF
--- a/providers/ou.rb
+++ b/providers/ou.rb
@@ -24,21 +24,24 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
-action :create do
-  if node['os_version'] < '6.1'
-    windows_ad_ou_2008 "#{new_resource.name}" do
+
+action :create do # ~FC017
+  require 'chef/win32/version'
+  win_ver = Chef::ReservedNames::Win32::Version.new
+  if win_ver.windows_server_2008? || win_ver.windows_server_2008_r2?
+    windows_ad_ou_2008 new_resource.name do
       action :create
-      ou "#{new_resource.ou}"
-      domain_name "#{new_resource.domain_name}"    
+      ou new_resource.ou unless new_resource.ou.nil?
+      domain_name new_resource.domain_name
     end
   elsif node['os_version'] >= '6.2'
-    windows_ad_ou_2012 "#{new_resource.name}" do
+    windows_ad_ou_2012 new_resource.name do
       action :create
-      path "#{new_resource.ou}" unless new_resource.ou.nil?
-      domain_name "#{new_resource.domain_name}"
+      path new_resource.ou unless new_resource.ou.nil?
+      domain_name new_resource.domain_name
     end
   else
-    Chef::Log.error("This version of Windows is not supported")
+    Chef::Log.error('This version of Windows is not supported')
   end
 end
 


### PR DESCRIPTION
In the current implementation of generic OU provider, the version detection does not work correctly for Windows 2008 R2 (which has internal version 6.1.7601) - it does not fall to the expected condition branch  ( `node['os_version'] < '6.1'` ) and results in the error message `This version of Windows is not supported` even though it is actually supported. 
Once version problem is fixed, one more problem is discovered with correctly passing the `ou` attribute to the underlying `ou_2008` provider for the case, when ou is nill. For the fix - the same approach as for ou_2012 provider is used.

The code has been tested and validated on our Windows 2008 R2 vagrant test box, which was created via boxcutter from the official evaluation ISO  from Microsoft.