### PR TITLE
Fix warning: found = in conditional, should be ==

### DIFF
--- a/resources/domain.rb
+++ b/resources/domain.rb
@@ -32,7 +32,7 @@ action :create do
       cmd << " -SafeModeAdministratorPassword (convertto-securestring '#{new_resource.safe_mode_pass}' -asplaintext -Force)"
       cmd << ' -Force:$true'
       cmd << ' -NoRebootOnCompletion' unless new_resource.restart
-    elsif
+    else
       cmd = 'dcpromo -unattend'
       cmd << " -newDomain:#{new_resource.type}"
       cmd << " -NewDomainDNSName:#{new_resource.name}"


### PR DESCRIPTION
### Description

This PR fixes a typo in the domain resource conditional command selection.

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
